### PR TITLE
Only inject anti-tamper if specified in crproj

### DIFF
--- a/Confuser.Protections/AntiTamper/AntiTamperProtection.cs
+++ b/Confuser.Protections/AntiTamper/AntiTamperProtection.cs
@@ -52,8 +52,8 @@ namespace Confuser.Protections {
 			}
 
 			protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {
-                if (parameters.Targets.Count == 0)
-                    return;
+				if (parameters.Targets.Count == 0)
+					return;
 
 				Mode mode = parameters.GetParameter(context, context.CurrentModule, "mode", Mode.Normal);
 				IModeHandler modeHandler;
@@ -81,8 +81,8 @@ namespace Confuser.Protections {
 			}
 
 			protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {
-                if (parameters.Targets.Count == 0)
-                    return;
+				if (parameters.Targets.Count == 0)
+					return;
 
 				var modeHandler = context.Annotations.Get<IModeHandler>(context.CurrentModule, HandlerKey);
 				modeHandler.HandleMD((AntiTamperProtection)Parent, context, parameters);


### PR DESCRIPTION
Without this the AntiTamper.Normal is injected in each assembly along
with the new section, regardless if specified to be used in crproj file
and the injected method isn't doing anything.

EDIT: Sorry for 2 commits, but the indentation was off.
