### PR TITLE
Bug fix in InjectHelper

### DIFF
--- a/Confuser.Core/Helpers/InjectHelper.cs
+++ b/Confuser.Core/Helpers/InjectHelper.cs
@@ -101,6 +101,7 @@ namespace Confuser.Core.Helpers {
 			var newMethodDef = (MethodDef)ctx.Map[methodDef];
 
 			newMethodDef.Signature = ctx.Importer.Import(methodDef.Signature);
+			newMethodDef.Parameters.UpdateParameterTypes();
 
 			if (methodDef.ImplMap != null)
 				newMethodDef.ImplMap = new ImplMapUser(new ModuleRefUser(ctx.TargetModule, methodDef.ImplMap.Module.Name), methodDef.ImplMap.Name, methodDef.ImplMap.Attributes);


### PR DESCRIPTION
UpdateParameterTypes() need to be called in order for newMethodDef to
get a ParameterList. Without doing this SimplifyMacros fails on methods
containing "ldarg" instruction.

https://github.com/0xd4d/dnlib/blob/master/src/DotNet/ParameterList.cs#L158

This caused issues when injecting methods such as Confuser.Runtime.Lzma.Decompress, turning

```
ldarg.0
```

into 

```
ldarg null
```

because of: https://github.com/0xd4d/dnlib/blob/master/src/DotNet/Emit/MethodUtils.cs#L97 which causes an exception in dnlib when writing method: https://github.com/0xd4d/dnlib/blob/master/src/DotNet/Writer/MethodBodyWriterBase.cs#L359
