### PR TITLE
Remove ILOnly flag when x86 code is present

### DIFF
--- a/Confuser.Protections/Constants/InjectPhase.cs
+++ b/Confuser.Protections/Constants/InjectPhase.cs
@@ -46,6 +46,8 @@ namespace Confuser.Protections.Constants {
 						break;
 					case Mode.x86:
 						moduleCtx.ModeHandler = new x86Mode();
+                        			if ((context.CurrentModule.Cor20HeaderFlags & dnlib.DotNet.MD.ComImageFlags.ILOnly) != 0)
+                            				context.CurrentModuleWriterOptions.Cor20HeaderOptions.Flags &= ~dnlib.DotNet.MD.ComImageFlags.ILOnly;
 						break;
 					default:
 						throw new UnreachableException();

--- a/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
+++ b/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
@@ -63,7 +63,10 @@ namespace Confuser.Protections.ReferenceProxy {
 					break;
 				case EncodingType.x86:
 					ret.EncodingHandler = store.x86 ?? (store.x86 = new x86Encoding());
-					break;
+                    
+                        		if ((context.CurrentModule.Cor20HeaderFlags & dnlib.DotNet.MD.ComImageFlags.ILOnly) != 0)
+                        			context.CurrentModuleWriterOptions.Cor20HeaderOptions.Flags &= ~dnlib.DotNet.MD.ComImageFlags.ILOnly;
+                        		break;
 				default:
 					throw new UnreachableException();
 			}


### PR DESCRIPTION
Not sure if it would cause issues not doing it, but since they're mixed
mode assemblies they should not have ILOnly flag just like https://github.com/yck1509/ConfuserEx/blob/master/Confuser.Protections/ControlFlow/ControlFlowPhase.cs#L39.
