### PR TITLE
64-bit compatibility for JIT hook

### DIFF
--- a/Confuser.Runtime/AntiTamper.JIT.cs
+++ b/Confuser.Runtime/AntiTamper.JIT.cs
@@ -192,9 +192,6 @@ namespace Confuser.Runtime {
 			if (info != null &&
 			    info->scope == moduleHnd &&
 			    info->ILCode[0] == 0x14) {
-				ICorClassInfo* clsInfo = ICorStaticInfo.ICorClassInfo(ICorDynamicInfo.ICorStaticInfo(ICorJitInfo.ICorDynamicInfo(comp)));
-				int gmdSlot = 12 + (ver ? 2 : IntPtr.Size / 4);
-				var getMethodDef = (getMethodDefFromMethod)Marshal.GetDelegateForFunctionPointer(clsInfo->vfptr[gmdSlot], typeof (getMethodDefFromMethod));
 				uint token = ((uint)(0x06000000 + *(ushort*)info->ftn));
 
 				uint lo = 0, hi = len;


### PR DESCRIPTION
May not be the best solution, but this works for both 32-bit and 64-bit
applications that I tested whereas old hook crashed on 64-bit.

Method token remainder is always at info->ftn as far as I know.
