### PR TITLE
Added an optional build script flag to target the .NET Framework 4.5

### DIFF
--- a/Build/Build.cmd
+++ b/Build/Build.cmd
@@ -1,5 +1,5 @@
 @echo off
-%windir%\microsoft.net\framework\v4.0.30319\msbuild ..\Confuser2.sln /p:Configuration=Release "/p:Platform=Any CPU"
+%windir%\microsoft.net\framework\v4.0.30319\msbuild ..\Confuser2.sln /p:Configuration=Release "/p:Platform=Any CPU" /p:DefineConstants="%1"
 @IF %ERRORLEVEL% NEQ 0 GOTO err
 7z a ConfuserEx_bin.zip -tzip @files.lst
 @exit /B 0

--- a/Confuser.CLI/Confuser.CLI.csproj
+++ b/Confuser.CLI/Confuser.CLI.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Confuser.CLI</RootNamespace>
     <AssemblyName>Confuser.CLI</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" !$(DefineConstants.Contains('NET45')) ">v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" $(DefineConstants.Contains('NET45')) ">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -47,7 +48,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" Condition=" !$(DefineConstants.Contains('NET45')) ">
       <Private>True</Private>
       <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
     </Reference>

--- a/Confuser.Core/Confuser.Core.csproj
+++ b/Confuser.Core/Confuser.Core.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Confuser.Core</RootNamespace>
     <AssemblyName>Confuser.Core</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" !$(DefineConstants.Contains('NET45')) ">v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" $(DefineConstants.Contains('NET45')) ">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -43,7 +44,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" Condition=" !$(DefineConstants.Contains('NET45')) ">
       <Private>True</Private>
       <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
     </Reference>
@@ -119,7 +120,7 @@
     <Compile Include="Services\MarkerService.cs" />
     <Compile Include="Services\RandomService.cs" />
     <Compile Include="Services\TraceService.cs" />
-    <Compile Include="Tuples.cs" />
+    <Compile Include="Tuples.cs" Condition=" !$(DefineConstants.Contains('NET45')) " />
     <Compile Include="UnreachableException.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>

--- a/Confuser.DynCipher/Confuser.DynCipher.csproj
+++ b/Confuser.DynCipher/Confuser.DynCipher.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Confuser.DynCipher</RootNamespace>
     <AssemblyName>Confuser.DynCipher</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" !$(DefineConstants.Contains('NET45')) ">v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" $(DefineConstants.Contains('NET45')) ">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Confuser.Protections/Confuser.Protections.csproj
+++ b/Confuser.Protections/Confuser.Protections.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Confuser.Protections</RootNamespace>
     <AssemblyName>Confuser.Protections</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" !$(DefineConstants.Contains('NET45')) ">v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" $(DefineConstants.Contains('NET45')) ">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -41,7 +42,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" Condition=" !$(DefineConstants.Contains('NET45')) ">
       <Private>True</Private>
       <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
     </Reference>

--- a/Confuser.Protections/ReferenceProxy/StrongMode.cs
+++ b/Confuser.Protections/ReferenceProxy/StrongMode.cs
@@ -109,12 +109,17 @@ namespace Confuser.Protections.ReferenceProxy {
 
 			// Create proxy field
 			if (proxy.Item1 == null)
-				proxy.Item1 = CreateField(ctx, delegateType);
+				proxy = new Tuple<FieldDef,MethodDef>(
+					CreateField(ctx, delegateType),
+					proxy.Item2);
 
 			// Create proxy bridge
 			Debug.Assert(proxy.Item2 == null);
 
-			proxy.Item2 = CreateBridge(ctx, delegateType, proxy.Item1, sig);
+			proxy = new Tuple<FieldDef,MethodDef>(
+				proxy.Item1,
+				CreateBridge(ctx, delegateType, proxy.Item1, sig));
+
 			fields[key] = proxy;
 
 			// Replace instruction

--- a/Confuser.Protections/ReferenceProxy/x86Encoding.cs
+++ b/Confuser.Protections/ReferenceProxy/x86Encoding.cs
@@ -71,8 +71,11 @@ namespace Confuser.Protections.ReferenceProxy {
 		private void InjectNativeCode(object sender, ModuleWriterListenerEventArgs e) {
 			var writer = (ModuleWriter)sender;
 			if (e.WriterEvent == ModuleWriterEvent.MDEndWriteMethodBodies) {
-				foreach (var native in nativeCodes)
-					native.Item3 = writer.MethodBodies.Add(new MethodBody(native.Item2));
+				for (int n = 0; n < nativeCodes.Count; n++)
+					nativeCodes[n] = new Tuple<MethodDef,byte[],MethodBody>(
+						nativeCodes[n].Item1,
+						nativeCodes[n].Item2,
+						writer.MethodBodies.Add(new MethodBody(nativeCodes[n].Item2)));
 			} else if (e.WriterEvent == ModuleWriterEvent.EndCalculateRvasAndFileOffsets) {
 				foreach (var native in nativeCodes) {
 					uint rid = writer.MetaData.GetRid(native.Item1);

--- a/Confuser.Renamer/Confuser.Renamer.csproj
+++ b/Confuser.Renamer/Confuser.Renamer.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Confuser.Renamer</RootNamespace>
     <AssemblyName>Confuser.Renamer</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" !$(DefineConstants.Contains('NET45')) ">v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" $(DefineConstants.Contains('NET45')) ">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ConfuserEx/ConfuserEx.csproj
+++ b/ConfuserEx/ConfuserEx.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConfuserEx</RootNamespace>
     <AssemblyName>ConfuserEx</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" !$(DefineConstants.Contains('NET45')) ">v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" $(DefineConstants.Contains('NET45')) ">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -57,7 +58,7 @@
       <HintPath>..\deps\Ookii.Dialogs.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" Condition=" !$(DefineConstants.Contains('NET45')) ">
       <Private>True</Private>
       <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
     </Reference>
@@ -247,7 +248,7 @@
       </ReferencePath>
     </ItemGroup>
   </Target>
-  <PropertyGroup>
+  <PropertyGroup Condition=" !$(DefineConstants.Contains('NET45')) ">
     <CoreCompileDependsOn>solveAliasProblem;$(PrepareResourcesDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
 </Project>

--- a/ConfuserEx/ViewModel/UI/ProtectTabVM.cs
+++ b/ConfuserEx/ViewModel/UI/ProtectTabVM.cs
@@ -1,4 +1,6 @@
-﻿extern alias PTL;
+﻿#if !NET45
+extern alias PTL;
+#endif
 using System;
 using System.Windows;
 using System.Windows.Documents;
@@ -7,7 +9,11 @@ using System.Windows.Media;
 using Confuser.Core;
 using Confuser.Core.Project;
 using GalaSoft.MvvmLight.Command;
+#if !NET45
 using PTL::System.Threading;
+#else
+using System.Threading;
+#endif
 
 // http://connect.microsoft.com/VisualStudio/feedback/details/615953/
 


### PR DESCRIPTION
I was able to get ConfuserEx to run just fine with Mono on OS/X.  The only trouble I ran into was that the TaskParallelLibrary back-port is not compatible with Mono (seems it uses Windows-only native libraries under the hood).  By changing the target framework to 4.5 and removing the reference to TaskParallelLibrary (since it is unnecessary when targeting .NET 4.5) I was able to get it to work.

.NET 4.0+ also includes its own (immutable) Tuple types so I excluded the Tuples.cs file from the build.  This also required changes in a few places where the .Item properties of tuples were set directly so that the code works with both framework versions.

Finally, the "extern alias PTL" workaround is unnecessary for .NET 4.5 so I excluded that as well.

The framework target is set by an optional command-line parameter to Build.cmd:

```
Build.cmd NET45
```

Would you consider accepting this pull request, or providing feedback if something needs to be changed in order to have it accepted?
