### PR TITLE
fixes typo bug in ObfAttrMarker

### DIFF
--- a/Confuser.CLI/ObfAttrMarker.cs
+++ b/Confuser.CLI/ObfAttrMarker.cs
@@ -277,7 +277,7 @@ namespace Confuser.CLI {
 					ProcessMember(prop.GetMethod, context, stack);
 				}
 				if (prop.SetMethod != null) {
-					ProcessMember(prop.GetMethod, context, stack);
+					ProcessMember(prop.SetMethod, context, stack);
 				}
 				foreach (var m in prop.OtherMethods)
 					ProcessMember(m, context, stack);


### PR DESCRIPTION
Here's my second attempt. Now the only change in the pull request is the one character that fixes this bug.
