### PR TITLE
fix renaming of wpf-applications from CLi

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -11,6 +11,9 @@ namespace Confuser.CLI {
 	internal class Program {
 		static int Main(string[] args) {
 			ConsoleColor original = Console.ForegroundColor;
+
+            UriParser.Register(new GenericUriParser (GenericUriParserOptions.GenericAuthority), "pack", -1);
+
 			Console.ForegroundColor = ConsoleColor.White;
 			string originalTitle = Console.Title;
 			Console.Title = "ConfuserEx";


### PR DESCRIPTION
this fixes issue  #201 (created by myself)

adding pack according to http://www.yac.com.pl/mt.texts.wpf-tests-pack-uri-handling.en.html and https://msdn.microsoft.com/en-us/library/aa480199.aspx#opcadmdl_topic3

