### PR TITLE
Add support for saving specifically marked files into a subfolder of output

### DIFF
--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -355,6 +355,11 @@ namespace Confuser.Core {
 			else {
 				output = context.CurrentModule.Name;
 			}
+		    var belongsToSubFolder = context.Annotations.Get<string>(context.CurrentModule, Marker.SubDirKey);
+            if(!String.IsNullOrWhiteSpace(belongsToSubFolder))
+			{
+			    output = Path.Combine(Path.GetDirectoryName(output), belongsToSubFolder, Path.GetFileName(output));
+			}
 			context.OutputPaths[context.CurrentModuleIndex] = output;
 		}
 

--- a/Confuser.Core/Marker.cs
+++ b/Confuser.Core/Marker.cs
@@ -25,6 +25,11 @@ namespace Confuser.Core {
 		/// </summary>
 		public static readonly object RulesKey = new object();
 
+        /// <summary>
+        ///     Annotation key of subdirectories.
+        /// </summary>
+        public static readonly object SubDirKey = new object();
+
 		/// <summary>
 		///     The packers available to use.
 		/// </summary>
@@ -136,6 +141,7 @@ namespace Confuser.Core {
 
 				context.Annotations.Set(module.Item2, SNKey, LoadSNKey(context, module.Item1.SNKeyPath == null ? null : Path.Combine(proj.BaseDirectory, module.Item1.SNKeyPath), module.Item1.SNKeyPassword));
 				context.Annotations.Set(module.Item2, RulesKey, rules);
+                context.Annotations.Set(module.Item2, SubDirKey, module.Item1.BelongsToSubFolder);
 
 				foreach (IDnlibDef def in module.Item2.FindDefinitions()) {
 					ApplyRules(context, def, rules);

--- a/Confuser.Core/Project/ConfuserPrj.xsd
+++ b/Confuser.Core/Project/ConfuserPrj.xsd
@@ -54,6 +54,7 @@
     <xs:attribute name="external" type="xs:boolean" default="false" />
     <xs:attribute name="snKey" type="xs:string" use="optional" />
     <xs:attribute name="snKeyPass" type="xs:string" use="optional" />
+    <xs:attribute name="belongsToSubFolder" type="xs:string" use="optional" />
   </xs:complexType>
 
 

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -40,6 +40,11 @@ namespace Confuser.Core.Project {
 		/// <value>The password of the strong name private key, or null if not necessary.</value>
 		public string SNKeyPassword { get; set; }
 
+        /// <summary>
+        /// Gets or sets the subfolder into which the resulting obfuscated file should be placed.
+        /// </summary>
+        public string BelongsToSubFolder { get; set; }
+
 		/// <summary>
 		///     Gets a list of protection rules applies to the module.
 		/// </summary>
@@ -102,6 +107,11 @@ namespace Confuser.Core.Project {
 				snKeyPassAttr.Value = SNKeyPassword;
 				elem.Attributes.Append(snKeyPassAttr);
 			}
+			if (BelongsToSubFolder != null) {
+				XmlAttribute toSubFolderAttr = xmlDoc.CreateAttribute("belongsToSubFolder");
+				toSubFolderAttr.Value = BelongsToSubFolder;
+				elem.Attributes.Append(toSubFolderAttr);
+			}
 
 
 			foreach (Rule i in Rules)
@@ -131,6 +141,11 @@ namespace Confuser.Core.Project {
 				SNKeyPassword = elem.Attributes["snKeyPass"].Value.NullIfEmpty();
 			else
 				SNKeyPassword = null;
+
+			if (elem.Attributes["belongsToSubFolder"] != null)
+				BelongsToSubFolder = elem.Attributes["belongsToSubFolder"].Value.NullIfEmpty();
+			else
+				BelongsToSubFolder = null;
 
 			Rules.Clear();
 			foreach (XmlElement i in elem.ChildNodes.OfType<XmlElement>()) {


### PR DESCRIPTION
By tagging module with extra parameter belongsToSubFolder, one could now redirect portion of the output files into a subfolder. This is useful if language files are under subfolders.

Example:
  <module path="es\Common.resources.dll" belongsToSubFolder="Es" />

When obfuscation is done, the obfuscated version of the file will be written into outputDirectory\Es instead of output directory itself. 
