### PR TITLE
Fix case where DeclaringType for FieldDef is null in constants encoding.

### DIFF
--- a/Confuser.Protections/Constants/EncodePhase.cs
+++ b/Confuser.Protections/Constants/EncodePhase.cs
@@ -285,7 +285,8 @@ namespace Confuser.Protections.Constants {
 									ldc.Remove(arrLen);
 							}
 
-							dataField.DeclaringType.Fields.Remove(dataField);
+                            if(dataField.DeclaringType!=null)
+							    dataField.DeclaringType.Fields.Remove(dataField);
 							var value = new byte[dataField.InitialValue.Length + 4];
 							value[0] = (byte)(arrLen >> 0);
 							value[1] = (byte)(arrLen >> 8);


### PR DESCRIPTION
Occurs with the following example

    string input = "a,b,c,d,a,b,c";
    string[] stringArr = input.Split(new[] { 'a', 'b', 'c' }, 5);

null check seems to be sufficient.