### PR TITLE
Fixing pack URI problems for command line use.

### DIFF
--- a/Confuser.Renamer/BAML/BAMLAnalyzer.cs
+++ b/Confuser.Renamer/BAML/BAMLAnalyzer.cs
@@ -24,7 +24,9 @@ namespace Confuser.Renamer.BAML {
 		readonly Dictionary<ushort, TypeSig> typeRefs = new Dictionary<ushort, TypeSig>();
 		readonly Dictionary<string, List<Tuple<AssemblyDef, string>>> xmlns = new Dictionary<string, List<Tuple<AssemblyDef, string>>>();
 
-		IKnownThings things;
+        readonly string packScheme = System.IO.Packaging.PackUriHelper.UriSchemePack + "://";
+
+        IKnownThings things;
 
 		KnownThingsv3 thingsv3;
 		KnownThingsv4 thingsv4;
@@ -503,7 +505,7 @@ namespace Confuser.Renamer.BAML {
 							src = match.Groups[1].Value;
 
 						if (!src.Contains("//")) {
-							var rel = new Uri(new Uri("pack://application:,,,/" + CurrentBAMLName), src);
+							var rel = new Uri(new Uri(packScheme + "application:,,,/" + CurrentBAMLName), src);
 							src = rel.LocalPath;
 						}
 						var reference = new BAMLPropertyReference(rec);

--- a/Confuser.Renamer/Confuser.Renamer.csproj
+++ b/Confuser.Renamer/Confuser.Renamer.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
URI format exception occurs when using the command line on XAML. "Pack" scheme is only automatically registered when run from a WPF application, using PackUriHelper registers the scheme: http://stackoverflow.com/questions/6005398/uriformatexception-invalid-uri-invalid-port-specified