### PR TITLE
Forced removing of local variables

### DIFF
--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -32,15 +32,15 @@ namespace Confuser.Renamer {
 					RickRoller.CommenceRickroll(context, (ModuleDef)def);
 
 				bool canRename = service.CanRename(def);
-				if (def is MethodDef)
-					if (canRename && parameters.GetParameter(context, def, "renameArgs", true)) {
-						var methodDef = (MethodDef)def;
-						foreach (ParamDef param in ((MethodDef)def).ParamDefs)
-							param.Name = null;
-						//always attempt remove locals for command line support
-						if (methodDef.HasBody)
-							foreach (var variable in methodDef.Body.Variables)
-								variable.Name = null;
+				if (def is MethodDef) {
+                    var methodDef = (MethodDef)def;
+                    //always attempt remove locals for command line support
+                    if (methodDef.HasBody)
+                            foreach (var variable in methodDef.Body.Variables)
+                                variable.Name = string.Empty;
+                    if (canRename && parameters.GetParameter(context, def, "renameArgs", true)) 
+						    foreach (ParamDef param in ((MethodDef)def).ParamDefs)
+							    param.Name = null;
 					}
 
 				if (!canRename)

--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -34,8 +34,13 @@ namespace Confuser.Renamer {
 				bool canRename = service.CanRename(def);
 				if (def is MethodDef)
 					if (canRename && parameters.GetParameter(context, def, "renameArgs", true)) {
+						var methodDef = (MethodDef)def;
 						foreach (ParamDef param in ((MethodDef)def).ParamDefs)
 							param.Name = null;
+						//always attempt remove locals for command line support
+						if (methodDef.HasBody)
+							foreach (var variable in methodDef.Body.Variables)
+								variable.Name = null;
 					}
 
 				if (!canRename)


### PR DESCRIPTION
There is a difference in behavior between running on the command line or the application. These commits make the command line also remove all local variables within methods (like the application does). 

This is done without a parameter to control it - perhaps it should have a parameter to switch this on/off as required, not sure.