### PR TITLE
Sequential renaming mode

### DIFF
--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -47,6 +47,7 @@ namespace Confuser.Renamer {
 		readonly VTableStorage storage;
 		AnalyzePhase analyze;
 		readonly Dictionary<string, string> nameDict = new Dictionary<string, string>();
+		private ulong sequentialCount = 0;
 
 		public NameService(ConfuserContext context) {
 			this.context = context;
@@ -141,6 +142,21 @@ namespace Confuser.Renamer {
 					var newName = "=" + Utils.EncodeString(hash, alphaNumCharset) + "=";
 					nameDict[newName] = name;
 					return newName;
+				case RenameMode.Sequential:
+					const string namePrefix = "#";
+					string sequentialName = namePrefix;
+					if (sequentialCount > uint.MaxValue)
+						sequentialName += Convert.ToBase64String(BitConverter.GetBytes(sequentialCount));
+					if (sequentialCount > ushort.MaxValue)
+						sequentialName += Convert.ToBase64String(BitConverter.GetBytes((uint)sequentialCount));
+					if (sequentialCount > byte.MaxValue)
+						sequentialName += Convert.ToBase64String(BitConverter.GetBytes((ushort)sequentialCount));
+					if (sequentialCount <= byte.MaxValue)
+						sequentialName += Convert.ToBase64String(new []{(byte)sequentialCount});
+					if (sequentialName == namePrefix)
+						throw new UnreachableException();
+					sequentialCount++;
+					return sequentialName;
 			}
 			throw new NotSupportedException("Rename mode '" + mode + "' is not supported.");
 		}

--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -126,8 +126,24 @@ namespace Confuser.Renamer {
 				return "";
 			if (mode == RenameMode.Debug)
 				return "_" + name;
+		    if (mode == RenameMode.Sequential) {
+		        const string namePrefix = "#";
+		        string sequentialName = namePrefix;
+		        if (sequentialCount > uint.MaxValue)
+		            sequentialName += Convert.ToBase64String(BitConverter.GetBytes(sequentialCount));
+		        if (sequentialCount > ushort.MaxValue)
+		            sequentialName += Convert.ToBase64String(BitConverter.GetBytes((uint) sequentialCount));
+		        if (sequentialCount > byte.MaxValue)
+		            sequentialName += Convert.ToBase64String(BitConverter.GetBytes((ushort) sequentialCount));
+		        if (sequentialCount <= byte.MaxValue)
+		            sequentialName += Convert.ToBase64String(new[] {(byte) sequentialCount});
+		        if (sequentialName == namePrefix)
+		            throw new UnreachableException();
+		        sequentialCount++;
+		        return sequentialName;
+		    }
 
-			byte[] hash = Utils.Xor(Utils.SHA1(Encoding.UTF8.GetBytes(name)), nameSeed);
+		    byte[] hash = Utils.Xor(Utils.SHA1(Encoding.UTF8.GetBytes(name)), nameSeed);
 
 			switch (mode) {
 				case RenameMode.Empty:
@@ -142,21 +158,6 @@ namespace Confuser.Renamer {
 					var newName = "=" + Utils.EncodeString(hash, alphaNumCharset) + "=";
 					nameDict[newName] = name;
 					return newName;
-				case RenameMode.Sequential:
-					const string namePrefix = "#";
-					string sequentialName = namePrefix;
-					if (sequentialCount > uint.MaxValue)
-						sequentialName += Convert.ToBase64String(BitConverter.GetBytes(sequentialCount));
-					if (sequentialCount > ushort.MaxValue)
-						sequentialName += Convert.ToBase64String(BitConverter.GetBytes((uint)sequentialCount));
-					if (sequentialCount > byte.MaxValue)
-						sequentialName += Convert.ToBase64String(BitConverter.GetBytes((ushort)sequentialCount));
-					if (sequentialCount <= byte.MaxValue)
-						sequentialName += Convert.ToBase64String(new []{(byte)sequentialCount});
-					if (sequentialName == namePrefix)
-						throw new UnreachableException();
-					sequentialCount++;
-					return sequentialName;
 			}
 			throw new NotSupportedException("Rename mode '" + mode + "' is not supported.");
 		}

--- a/Confuser.Renamer/RenameMode.cs
+++ b/Confuser.Renamer/RenameMode.cs
@@ -7,6 +7,7 @@ namespace Confuser.Renamer {
 		ASCII,
 		Letters,
 		Decodable,
-		Debug
+		Debug,
+        Sequential
 	}
 }


### PR DESCRIPTION
Proposal for a new renaming mode - you can throw this away if you want.

Sequential renaming encoded as base64 string. 
Format example #AA==.#AQ==.#Ag==

Will result in slightly smaller assemblies... Otherwise no real value yet. It could be enhanced in the future with tracking naming scopes so that sequence number is within a namespace/class equivalent to the following 
  
    namespace #AA=={
      class #AA=={
        method #AA=={}
      }
    } 

Could also support being written to symbol.map but this has not been tested in more complex scenarios - like decoding stacktraces with names from multiple independently obfuscated assemblies...