### PR TITLE
Reversible renaming

### DIFF
--- a/Confuser.Core/ObfAttrParser.cs
+++ b/Confuser.Core/ObfAttrParser.cs
@@ -46,6 +46,35 @@ namespace Confuser.Core {
 			return false;
 		}
 
+	    private bool ReadStringOrId(StringBuilder sb) {
+	        return ReadString(sb) || ReadId(sb);
+	    }
+
+	    /// <summary>
+        /// Reads a string between single quotes.
+        /// </summary>
+        /// <param name="sb">The target result.</param>
+        /// <returns></returns>
+		bool ReadString(StringBuilder sb)
+		{
+		    if (Peek() != '\'')
+		        return false;
+            index++;
+            while (index < str.Length) 
+            {
+				switch (str[index]) 
+                {
+					case '\'':
+                        index++;
+						return true;
+					default:
+						sb.Append(str[index++]);
+						break;
+				}
+			}
+			return false;
+		}
+
 		void Expect(char chr) {
 			if (str[index] != chr)
 				throw new ArgumentException("Expect '" + chr + "' at position " + (index + 1) + ".");
@@ -161,7 +190,7 @@ namespace Confuser.Core {
 						buffer.Length = 0;
 
 						Expect('=');
-						if (!ReadId(buffer))
+						if (!ReadStringOrId(buffer))
 							throw new ArgumentException("Unexpected end of string in ReadParam state.");
 						paramValue = buffer.ToString();
 						buffer.Length = 0;

--- a/Confuser.Protections/AntiDebugProtection.cs
+++ b/Confuser.Protections/AntiDebugProtection.cs
@@ -121,7 +121,9 @@ namespace Confuser.Protections {
 							}
 						}
 						if (ren) {
-							member.Name = name.ObfuscateName(member.Name, RenameMode.Unicode);
+						    var renameMode = name.GetRenameMode(member);
+						    var reversibleCryptoTransform = name.GetReversibleCryptoTransform(member);
+							member.Name = name.ObfuscateName(member.Name, renameMode, reversibleCryptoTransform);
 							name.SetCanRename(member, false);
 						}
 					}

--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -21,10 +21,13 @@ namespace Confuser.Renamer {
 			get { return "Name analysis"; }
 		}
 
-		void ParseParameters(IDnlibDef def, ConfuserContext context, NameService service, ProtectionParameters parameters) {
+		void ParseParameters(IDnlibDef def, ConfuserContext context, INameService service, ProtectionParameters parameters) {
 			var mode = parameters.GetParameter<RenameMode?>(context, def, "mode", null);
 			if (mode != null)
 				service.SetRenameMode(def, mode.Value);
+            var password = parameters.GetParameter<string>(context, def, "password");
+		    if (password != null)
+		        service.SetReversibleEncryptionKey(def, password);
 		}
 
 		protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {

--- a/Confuser.Renamer/Confuser.Renamer.csproj
+++ b/Confuser.Renamer/Confuser.Renamer.csproj
@@ -70,6 +70,7 @@
     <Compile Include="BAML\KnownThingsv3.cs" />
     <Compile Include="BAML\PropertyPath.cs" />
     <Compile Include="GenericArgumentResolver.cs" />
+    <Compile Include="NameReverser.cs" />
     <Compile Include="PostRenamePhase.cs" />
     <Compile Include="IRenamer.cs" />
     <Compile Include="NameProtection.cs" />

--- a/Confuser.Renamer/NameReverser.cs
+++ b/Confuser.Renamer/NameReverser.cs
@@ -41,14 +41,16 @@ namespace Confuser.Renamer
                 if (encodedAndRaw.Length == 1)
                     decoded.Append(encodedAndRaw[0]);
                 else {
-                    var base64String =new StringBuilder(encodedAndRaw[0]);
+                    var base64String = new StringBuilder(encodedAndRaw[0]);
+                    // some stack traces add a backslash
+                    base64String = base64String.Replace(@"\", "");
                     while (base64String.Length%4 != 0)
                         base64String.Append('=');
                     // now, since it may actually be anything, try to convert, decrypt, etc. Any failure and we're inserting the original text
                     try {
                         var encryptedBytes = Convert.FromBase64String(base64String.ToString());
                         var nameBytes = decryptor.TransformFinalBlock(encryptedBytes, 0, encryptedBytes.Length);
-                        var name = Encoding.UTF8.GetString(nameBytes);
+                        var name = Encoding.UTF8.GetString(nameBytes, NameService.DummyHeaderLength, nameBytes.Length - NameService.DummyHeaderLength);
                         decoded.Append(name);
                     }
                     catch {

--- a/Confuser.Renamer/NameReverser.cs
+++ b/Confuser.Renamer/NameReverser.cs
@@ -13,8 +13,6 @@ namespace Confuser.Renamer
     {
         private readonly ICryptoTransform decryptor;
 
-        private const string Base64Table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-
         public NameReverser(string encryptionPassword)
         {
             var algorithm = NameService.CreateReversibleAlgorithm(encryptionPassword);

--- a/Confuser.Renamer/NameReverser.cs
+++ b/Confuser.Renamer/NameReverser.cs
@@ -1,0 +1,78 @@
+﻿
+namespace Confuser.Renamer
+{
+    using System;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    /// <summary>
+    /// Allows to reverse name encryption
+    /// </summary>
+    public class NameReverser : IDisposable
+    {
+        private readonly ICryptoTransform decryptor;
+
+        private const string Base64Table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+        public NameReverser(string encryptionPassword)
+        {
+            var algorithm = NameService.CreateReversibleAlgorithm(encryptionPassword);
+            decryptor = algorithm.CreateDecryptor();
+        }
+
+        public void Dispose()
+        {
+            decryptor.Dispose();
+        }
+
+        /// <summary>
+        /// Decodes the specified string (which may contain several encoded names).
+        /// </summary>
+        /// <param name="s">The string do decode.</param>
+        /// <returns></returns>
+        public string Decode(string s) {
+            // split around start marker
+            var parts = s.Split(new[] {NameService.ReversibleNameStartTag}, StringSplitOptions.None);
+            // first part is always raw
+            var decoded=new StringBuilder(parts[0]);
+            // then process remaining parts
+            foreach (var part in parts.Skip(1)) {
+                // then split around end marker
+                var encodedAndRaw = part.Split(new[] {NameService.ReversibleNameEndTag}, 2, StringSplitOptions.None);
+                if (encodedAndRaw.Length == 1)
+                    decoded.Append(encodedAndRaw[0]);
+                else {
+                    var base64String =new StringBuilder(encodedAndRaw[0]);
+                    while (base64String.Length%4 != 0)
+                        base64String.Append('=');
+                    // now, since it may actually be anything, try to convert, decrypt, etc. Any failure and we're inserting the original text
+                    try {
+                        var encryptedBytes = Convert.FromBase64String(base64String.ToString());
+                        var nameBytes = decryptor.TransformFinalBlock(encryptedBytes, 0, encryptedBytes.Length);
+                        var name = Encoding.UTF8.GetString(nameBytes);
+                        decoded.Append(name);
+                    }
+                    catch {
+                        decoded.Append(NameService.ReversibleNameStartTag);
+                        decoded.Append(encodedAndRaw[0]);
+                        decoded.Append(NameService.ReversibleNameEndTag);
+                    }
+                    decoded.Append(encodedAndRaw[1]);
+                }
+            }
+            return decoded.ToString();
+        }
+
+        /// <summary>
+        /// Decodes the specified string (which may contain several encoded names).
+        /// </summary>
+        /// <param name="s">The string to decode.</param>
+        /// <param name="encryptionPassword">The encryption password.</param>
+        /// <returns></returns>
+        public static string Decode(string s, string encryptionPassword) {
+            using (var nameReverser = new NameReverser(encryptionPassword))
+                return nameReverser.Decode(s);
+        }
+    }
+}

--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -136,22 +136,20 @@ namespace Confuser.Renamer {
 			if (mode == RenameMode.Debug)
 				return "_" + name;
 
-			byte[] hash = Utils.Xor(Utils.SHA1(Encoding.UTF8.GetBytes(name)), nameSeed);
-
-			switch (mode) {
+		    switch (mode) {
 				case RenameMode.Empty:
 					return "";
 				case RenameMode.Unicode:
-					return Utils.EncodeString(hash, unicodeCharset) + "\u202e";
+					return Utils.EncodeString(GetNameHash(name), unicodeCharset) + "\u202e";
 				case RenameMode.Letters:
-					return Utils.EncodeString(hash, letterCharset);
+					return Utils.EncodeString(GetNameHash(name), letterCharset);
 				case RenameMode.ASCII:
-					return Utils.EncodeString(hash, asciiCharset);
+					return Utils.EncodeString(GetNameHash(name), asciiCharset);
 				case RenameMode.Decodable: {
 						if (nameMap1.ContainsKey(name))
 							return nameMap1[name];
 						IncrementNameId();
-						var newName = "_" + Utils.EncodeString(hash, alphaNumCharset) + "_";
+						var newName = "_" + Utils.EncodeString(GetNameHash(name), alphaNumCharset) + "_";
 						nameMap2[newName] = name;
 						nameMap1[name] = newName;
 						return newName;
@@ -169,7 +167,13 @@ namespace Confuser.Renamer {
 			throw new NotSupportedException("Rename mode '" + mode + "' is not supported.");
 		}
 
-		public string RandomName() {
+	    private byte[] GetNameHash(string name)
+	    {
+	        byte[] hash = Utils.Xor(Utils.SHA1(Encoding.UTF8.GetBytes(name)), nameSeed);
+	        return hash;
+	    }
+
+	    public string RandomName() {
 			return RandomName(RenameMode.Unicode);
 		}
 

--- a/Confuser.Renamer/RenameMode.cs
+++ b/Confuser.Renamer/RenameMode.cs
@@ -8,6 +8,7 @@ namespace Confuser.Renamer {
 		Letters,
 		Decodable,
 		Sequential,
-		Debug
+		Debug,
+        Reversible,
 	}
 }

--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -42,6 +42,7 @@ namespace Confuser.Renamer {
 					continue;
 
 				RenameMode mode = service.GetRenameMode(def);
+			    var reversibleCryptoTransform = service.GetReversibleCryptoTransform(def);
 
 				IList<INameReference> references = service.GetReferences(def);
 				bool cancel = false;
@@ -54,25 +55,25 @@ namespace Confuser.Renamer {
 
 				if (def is TypeDef) {
 					var typeDef = (TypeDef)def;
-					if (parameters.GetParameter(context, def, "flatten", true)) {
-						typeDef.Name = service.ObfuscateName(typeDef.FullName, mode);
-						typeDef.Namespace = "";
-					}
-					else {
-						typeDef.Namespace = service.ObfuscateName(typeDef.Namespace, mode);
-						typeDef.Name = service.ObfuscateName(typeDef.Name, mode);
-					}
-					foreach (var param in typeDef.GenericParameters)
+				    if (parameters.GetParameter(context, def, "flatten", true)) {
+				        typeDef.Name = service.ObfuscateName(typeDef.FullName, mode, reversibleCryptoTransform);
+				        typeDef.Namespace = "";
+				    }
+				    else {
+				        typeDef.Namespace = service.ObfuscateName(typeDef.Namespace, mode, reversibleCryptoTransform);
+				        typeDef.Name = service.ObfuscateName(typeDef.Name, mode, reversibleCryptoTransform);
+				    }
+				    foreach (var param in typeDef.GenericParameters)
 						param.Name = ((char)(param.Number + 1)).ToString();
 				}
 				else if (def is MethodDef) {
-					foreach (var param in ((MethodDef)def).GenericParameters)
-						param.Name = ((char)(param.Number + 1)).ToString();
-					
-					def.Name = service.ObfuscateName(def.Name, mode);
+				    foreach (var param in ((MethodDef) def).GenericParameters)
+				        param.Name = ((char) (param.Number + 1)).ToString();
+
+				    def.Name = service.ObfuscateName(def.Name, mode, reversibleCryptoTransform);
 				}
 				else
-					def.Name = service.ObfuscateName(def.Name, mode);
+				    def.Name = service.ObfuscateName(def.Name, mode, reversibleCryptoTransform);
 
 				foreach (INameReference refer in references.ToList()) {
 					if (!refer.UpdateNameReference(context, service)) {

--- a/Confuser2.sln.DotSettings
+++ b/Confuser2.sln.DotSettings
@@ -1,0 +1,16 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CommonFormatter/ALIGNMENT_TAB_FILL_STYLE/@EntryValue">USE_TABS_ONLY</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INVOCABLE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/TYPE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_OWNER_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ConfuserEx/StackTraceDecoder.xaml
+++ b/ConfuserEx/StackTraceDecoder.xaml
@@ -7,6 +7,7 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="36px" />
+            <RowDefinition Height="36px" />
             <RowDefinition Height="40px" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
@@ -22,10 +23,14 @@
                      local:FileDragDrop.Command="{x:Static local:FileDragDrop.FileCmd}" />
         </DockPanel>
         <DockPanel Grid.Row="1">
+            <Label DockPanel.Dock="Left" VerticalAlignment="Center" HorizontalAlignment="Right">Or password (for reversible name encryption):</Label>
+            <TextBox x:Name="PasswordBox" Margin="5" VerticalContentAlignment="Center" />
+        </DockPanel>
+        <DockPanel Grid.Row="2">
             <Button DockPanel.Dock="Right" Margin="5" Padding="10,0,10,0" Click="Decode_Click">Decode!</Button>
             <Label x:Name="status" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5,2,10,2" />
         </DockPanel>
-        <TextBox x:Name="stackTrace" Grid.Row="2" Margin="5" AcceptsReturn="True" FontFamily="Consolas"
+        <TextBox x:Name="stackTrace" Grid.Row="3" Margin="5" AcceptsReturn="True" FontFamily="Consolas"
                  ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Visible" />
     </Grid>
 </Window>

--- a/ConfuserEx/StackTraceDecoder.xaml.cs
+++ b/ConfuserEx/StackTraceDecoder.xaml.cs
@@ -8,7 +8,9 @@ using Confuser.Core;
 using Ookii.Dialogs.Wpf;
 
 namespace ConfuserEx {
-	/// <summary>
+    using Confuser.Renamer;
+
+    /// <summary>
 	///     Interaction logic for StackTraceDecoder.xaml
 	/// </summary>
 	public partial class StackTraceDecoder : Window {
@@ -59,7 +61,10 @@ namespace ConfuserEx {
 
 		void Decode_Click(object sender, RoutedEventArgs e) {
 			var trace = stackTrace.Text;
-			stackTrace.Text = symbolMatcher.Replace(trace, DecodeSymbol);
+		    if (!string.IsNullOrEmpty(PasswordBox.Text))
+		        stackTrace.Text = NameReverser.Decode(trace, PasswordBox.Text);
+		    else
+		        stackTrace.Text = symbolMatcher.Replace(trace, DecodeSymbol);
 		}
 
 		string DecodeSymbol(Match match) {


### PR DESCRIPTION
This is something that was present in Eazfuscator (that I'm divorcing with :smile:).
This idea is to create reversible name encryption (using a password and AES encryption).
This works as follows (using an attribute):
`[assembly: Obfuscation(Exclude = false, Feature = "preset(normal);`**`+rename(mode=reversible,password='`*`any password you like`*`');")]`**
I also did some changes in the GUI to decode from there.
And finally, there is a new class in `Confuser.Renamer` named `NameReverser` with a `Decode()` method (two overloads of it: static or instance method). Simply provider a stack trace and the encryption password and the method will decode it.