### PR TITLE
C# 6 null propagation generates IL which causes invalid IL after SwitchMangler.

### DIFF
--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -272,8 +272,15 @@ namespace Confuser.Protections.ControlFlow {
 				switchHdr.Add(Instruction.Create(OpCodes.Rem_Un));
 				switchHdr.Add(switchInstr);
 
-				ctx.AddJump(switchHdr, statements.Last.Value[0]);
-				ctx.AddJunk(switchHdr);
+			    if (trace.BeforeStack[statements.Last.Value[0].Offset] == 0)
+			    {
+                    ctx.AddJump(switchHdr, statements.Last.Value[0]);
+                }
+			    else
+			    {
+                    ctx.AddJump(switchHdr, switchHdr[0]);
+                }
+                ctx.AddJunk(switchHdr);
 
 				var operands = new Instruction[statements.Count];
 				current = statements.First;
@@ -292,28 +299,37 @@ namespace Confuser.Protections.ControlFlow {
 							int brKey;
 							if (!trace.IsBranchTarget(newStatement.Last().Offset) &&
 							    statementKeys.TryGetValue(target, out brKey)) {
-								var targetKey = predicate != null ? predicate.GetSwitchKey(brKey) : brKey;
-								var unkSrc = hasUnknownSource(newStatement);
 
-								newStatement.RemoveAt(newStatement.Count - 1);
+                                if (trace.BeforeStack[target.Offset] == 0)
+                                {
+								    var targetKey = predicate != null ? predicate.GetSwitchKey(brKey) : brKey;
+								    var unkSrc = hasUnknownSource(newStatement);
 
-								if (unkSrc) {
-									newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
-								}
-								else {
-									var thisKey = key[i];
-									var r = ctx.Random.NextInt32();
-									newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
-									newStatement.Add(Instruction.CreateLdcI4(r));
-									newStatement.Add(Instruction.Create(OpCodes.Mul));
-									newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey * r) ^ targetKey));
-									newStatement.Add(Instruction.Create(OpCodes.Xor));
-								}
+								    newStatement.RemoveAt(newStatement.Count - 1);
 
-								ctx.AddJump(newStatement, switchHdr[1]);
-								ctx.AddJunk(newStatement);
-								operands[keyId[i]] = newStatement[0];
-								converted = true;
+								    if (unkSrc) {
+									    newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
+								    }
+								    else {
+									    var thisKey = key[i];
+									    var r = ctx.Random.NextInt32();
+									    newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
+									    newStatement.Add(Instruction.CreateLdcI4(r));
+									    newStatement.Add(Instruction.Create(OpCodes.Mul));
+									    newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey * r) ^ targetKey));
+									    newStatement.Add(Instruction.Create(OpCodes.Xor));
+								    }
+
+								    ctx.AddJump(newStatement, switchHdr[1]);
+								    ctx.AddJunk(newStatement);
+                                }
+
+                                if (trace.BeforeStack[newStatement[0].Offset] == 0)
+                                {
+                                    operands[keyId[i]] = newStatement[0];
+                                }
+
+                                converted = true;
 							}
 						}
 						else if (newStatement.Last().IsConditionalBranch()) {
@@ -323,72 +339,98 @@ namespace Confuser.Protections.ControlFlow {
 							int brKey;
 							if (!trace.IsBranchTarget(newStatement.Last().Offset) &&
 							    statementKeys.TryGetValue(target, out brKey)) {
-								bool unkSrc = hasUnknownSource(newStatement);
-								int nextKey = key[i + 1];
-								OpCode condBr = newStatement.Last().OpCode;
-								newStatement.RemoveAt(newStatement.Count - 1);
 
-								if (ctx.Random.NextBoolean()) {
-									condBr = InverseBranch(condBr);
-									int tmp = brKey;
-									brKey = nextKey;
-									nextKey = tmp;
-								}
+                                if (trace.BeforeStack[target.Offset] == 0)
+                                {
+                                    bool unkSrc = hasUnknownSource(newStatement);
+								    int nextKey = key[i + 1];
+								    OpCode condBr = newStatement.Last().OpCode;
+								    newStatement.RemoveAt(newStatement.Count - 1);
 
-								var thisKey = key[i];
-								int r = 0, xorKey = 0;
-								if (!unkSrc) {
-									r = ctx.Random.NextInt32();
-									xorKey = thisKey * r;
-								}
+								    if (ctx.Random.NextBoolean()) {
+									    condBr = InverseBranch(condBr);
+									    int tmp = brKey;
+									    brKey = nextKey;
+									    nextKey = tmp;
+								    }
 
-								Instruction brKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(brKey) : brKey));
-								Instruction nextKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(nextKey) : nextKey));
-								Instruction pop = Instruction.Create(OpCodes.Pop);
+								    var thisKey = key[i];
+								    int r = 0, xorKey = 0;
+								    if (!unkSrc) {
+									    r = ctx.Random.NextInt32();
+									    xorKey = thisKey * r;
+								    }
 
-								newStatement.Add(Instruction.Create(condBr, brKeyInstr));
-								newStatement.Add(nextKeyInstr);
-								newStatement.Add(Instruction.Create(OpCodes.Dup));
-								newStatement.Add(Instruction.Create(OpCodes.Br, pop));
-								newStatement.Add(brKeyInstr);
-								newStatement.Add(Instruction.Create(OpCodes.Dup));
-								newStatement.Add(pop);
+								    Instruction brKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(brKey) : brKey));
+								    Instruction nextKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(nextKey) : nextKey));
+								    Instruction pop = Instruction.Create(OpCodes.Pop);
 
-								if (!unkSrc) {
-									newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
-									newStatement.Add(Instruction.CreateLdcI4(r));
-									newStatement.Add(Instruction.Create(OpCodes.Mul));
-									newStatement.Add(Instruction.Create(OpCodes.Xor));
-								}
+								    newStatement.Add(Instruction.Create(condBr, brKeyInstr));
+								    newStatement.Add(nextKeyInstr);
+								    newStatement.Add(Instruction.Create(OpCodes.Dup));
+								    newStatement.Add(Instruction.Create(OpCodes.Br, pop));
+								    newStatement.Add(brKeyInstr);
+								    newStatement.Add(Instruction.Create(OpCodes.Dup));
+								    newStatement.Add(pop);
 
-								ctx.AddJump(newStatement, switchHdr[1]);
-								ctx.AddJunk(newStatement);
-								operands[keyId[i]] = newStatement[0];
-								converted = true;
+								    if (!unkSrc) {
+									    newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
+									    newStatement.Add(Instruction.CreateLdcI4(r));
+									    newStatement.Add(Instruction.Create(OpCodes.Mul));
+									    newStatement.Add(Instruction.Create(OpCodes.Xor));
+								    }
+
+								    ctx.AddJump(newStatement, switchHdr[1]);
+								    ctx.AddJunk(newStatement);
+
+                                    converted = true;
+                                }
+
+                                if (trace.BeforeStack[newStatement[0].Offset] == 0)
+                                {
+                                    operands[keyId[i]] = newStatement[0];
+                                }
 							}
 						}
 
 						if (!converted) {
 							// Normal
 
-							var targetKey = predicate != null ? predicate.GetSwitchKey(key[i + 1]) : key[i + 1];
-							if (!hasUnknownSource(newStatement)) {
-								var thisKey = key[i];
-								var r = ctx.Random.NextInt32();
-								newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
-								newStatement.Add(Instruction.CreateLdcI4(r));
-								newStatement.Add(Instruction.Create(OpCodes.Mul));
-								newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey * r) ^ targetKey));
-								newStatement.Add(Instruction.Create(OpCodes.Xor));
-							}
-							else {
-								newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
-							}
+						    if (newStatement[newStatement.Count - 1].OpCode != OpCodes.Ret)
+						    {
+						        var nextStatement = current.Next;
+						        if (trace.BeforeStack[nextStatement.Value[0].Offset] == 0)
+						        {
+						            var targetKey = predicate != null ? predicate.GetSwitchKey(key[i + 1]) : key[i + 1];
+						            if (!hasUnknownSource(newStatement) && trace.BeforeStack[newStatement[0].Offset] == 0)
+						            {
+						                var thisKey = key[i];
+						                var r = ctx.Random.NextInt32();
+						                newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
+						                newStatement.Add(Instruction.CreateLdcI4(r));
+						                newStatement.Add(Instruction.Create(OpCodes.Mul));
+						                newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey*r) ^ targetKey));
+						                newStatement.Add(Instruction.Create(OpCodes.Xor));
+						            }
+						            else
+						            {
+						                newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
+						            }
 
-							ctx.AddJump(newStatement, switchHdr[1]);
-							ctx.AddJunk(newStatement);
-							operands[keyId[i]] = newStatement[0];
-						}
+						            ctx.AddJump(newStatement, switchHdr[1]);
+						            ctx.AddJunk(newStatement);
+						        }
+						        else
+						        {
+						            newStatement.Add(Instruction.Create(OpCodes.Br, nextStatement.Value[0]));
+						        }
+						    }
+
+						    if (trace.BeforeStack[newStatement[0].Offset] == 0)
+                            {
+                                operands[keyId[i]] = newStatement[0];
+                            }
+                        }
 					}
 					else
 						operands[keyId[i]] = switchHdr[0];
@@ -397,7 +439,20 @@ namespace Confuser.Protections.ControlFlow {
 					current = current.Next;
 					i++;
 				}
-				operands[keyId[i]] = current.Value[0];
+
+			    if (trace.BeforeStack[current.Value[0].Offset] == 0)
+			    {
+			        operands[keyId[i]] = current.Value[0];
+			    }
+
+			    for (i = 0; i < operands.Length; i++)
+			    {
+			        if (operands[i] == null)
+			        {
+			            operands[i] = switchHdr[0];
+			        }
+			    }
+
 				switchInstr.Operand = operands;
 
 				Instruction[] first = statements.First.Value;
@@ -405,15 +460,19 @@ namespace Confuser.Protections.ControlFlow {
 				Instruction[] last = statements.Last.Value;
 				statements.RemoveLast();
 
-				List<Instruction[]> newStatements = statements.ToList();
+				List<Instruction[]> newStatements = statements.Where(s => trace.BeforeStack[s[0].Offset] == 0).ToList();
 				ctx.Random.Shuffle(newStatements);
 
-				block.Instructions.Clear();
+                List<Instruction[]> newOrderedStatements = statements.Where(s => trace.BeforeStack[s[0].Offset] != 0).ToList();
+
+                block.Instructions.Clear();
 				block.Instructions.AddRange(first);
 				block.Instructions.AddRange(switchHdr);
 				foreach (var statement in newStatements)
 					block.Instructions.AddRange(statement);
-				block.Instructions.AddRange(last);
+                foreach (var statement in newOrderedStatements)
+                    block.Instructions.AddRange(statement);
+                block.Instructions.AddRange(last);
 			}
 		}
 	}

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -131,7 +131,7 @@ namespace Confuser.Protections.ControlFlow {
 						shouldSpilt = true;
 						break;
 				}
-				if ((instr.OpCode.OpCodeType != OpCodeType.Prefix && trace.AfterStack[instr.Offset] == 0) &&
+				if ((instr.OpCode.OpCodeType != OpCodeType.Prefix && (trace.AfterStack[instr.Offset] == 0 || instr.IsBr())) &&
 				    (shouldSpilt || ctx.Intensity > ctx.Random.NextDouble())) {
 					statements.AddLast(currentStatement.ToArray());
 					currentStatement.Clear();

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -305,9 +305,10 @@ namespace Confuser.Protections.ControlFlow {
 									var targetKey = predicate != null ? predicate.GetSwitchKey(brKey) : brKey;
 									var unkSrc = hasUnknownSource(newStatement);
 
-									newStatement.RemoveAt(newStatement.Count - 1);
+								    var initialBeforeStack = trace.BeforeStack[newStatement[0].Offset];
+                                    newStatement.RemoveAt(newStatement.Count - 1);
 
-									if (unkSrc) {
+									if (unkSrc || initialBeforeStack != 0) {
 										newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
 									}
 									else {

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -272,14 +272,14 @@ namespace Confuser.Protections.ControlFlow {
 				switchHdr.Add(Instruction.Create(OpCodes.Rem_Un));
 				switchHdr.Add(switchInstr);
 
-			    if (trace.BeforeStack[statements.Last.Value[0].Offset] == 0)
-			    {
-                    ctx.AddJump(switchHdr, statements.Last.Value[0]);
-                }
-			    else
-			    {
-                    ctx.AddJump(switchHdr, switchHdr[0]);
-                }
+				if (trace.BeforeStack[statements.Last.Value[0].Offset] == 0)
+				{
+					ctx.AddJump(switchHdr, statements.Last.Value[0]);
+				}
+				else
+				{
+					ctx.AddJump(switchHdr, switchHdr[0]);
+				}
                 ctx.AddJunk(switchHdr);
 
 				var operands = new Instruction[statements.Count];
@@ -300,36 +300,36 @@ namespace Confuser.Protections.ControlFlow {
 							if (!trace.IsBranchTarget(newStatement.Last().Offset) &&
 							    statementKeys.TryGetValue(target, out brKey)) {
 
-                                if (trace.BeforeStack[target.Offset] == 0)
-                                {
-								    var targetKey = predicate != null ? predicate.GetSwitchKey(brKey) : brKey;
-								    var unkSrc = hasUnknownSource(newStatement);
+								if (trace.BeforeStack[target.Offset] == 0)
+								{
+									var targetKey = predicate != null ? predicate.GetSwitchKey(brKey) : brKey;
+									var unkSrc = hasUnknownSource(newStatement);
 
-								    newStatement.RemoveAt(newStatement.Count - 1);
+									newStatement.RemoveAt(newStatement.Count - 1);
 
-								    if (unkSrc) {
-									    newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
-								    }
-								    else {
-									    var thisKey = key[i];
-									    var r = ctx.Random.NextInt32();
-									    newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
-									    newStatement.Add(Instruction.CreateLdcI4(r));
-									    newStatement.Add(Instruction.Create(OpCodes.Mul));
-									    newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey * r) ^ targetKey));
-									    newStatement.Add(Instruction.Create(OpCodes.Xor));
-								    }
+									if (unkSrc) {
+										newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
+									}
+									else {
+										var thisKey = key[i];
+										var r = ctx.Random.NextInt32();
+										newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
+										newStatement.Add(Instruction.CreateLdcI4(r));
+										newStatement.Add(Instruction.Create(OpCodes.Mul));
+										newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey * r) ^ targetKey));
+										newStatement.Add(Instruction.Create(OpCodes.Xor));
+									}
 
-								    ctx.AddJump(newStatement, switchHdr[1]);
-								    ctx.AddJunk(newStatement);
-                                }
+									ctx.AddJump(newStatement, switchHdr[1]);
+									ctx.AddJunk(newStatement);
+								}
 
-                                if (trace.BeforeStack[newStatement[0].Offset] == 0)
-                                {
-                                    operands[keyId[i]] = newStatement[0];
-                                }
+								if (trace.BeforeStack[newStatement[0].Offset] == 0)
+								{
+									operands[keyId[i]] = newStatement[0];
+								}
 
-                                converted = true;
+								converted = true;
 							}
 						}
 						else if (newStatement.Last().IsConditionalBranch()) {
@@ -340,97 +340,97 @@ namespace Confuser.Protections.ControlFlow {
 							if (!trace.IsBranchTarget(newStatement.Last().Offset) &&
 							    statementKeys.TryGetValue(target, out brKey)) {
 
-                                if (trace.BeforeStack[target.Offset] == 0)
-                                {
-                                    bool unkSrc = hasUnknownSource(newStatement);
-								    int nextKey = key[i + 1];
-								    OpCode condBr = newStatement.Last().OpCode;
-								    newStatement.RemoveAt(newStatement.Count - 1);
+								if (trace.BeforeStack[target.Offset] == 0)
+								{
+									bool unkSrc = hasUnknownSource(newStatement);
+									int nextKey = key[i + 1];
+									OpCode condBr = newStatement.Last().OpCode;
+									newStatement.RemoveAt(newStatement.Count - 1);
 
-								    if (ctx.Random.NextBoolean()) {
-									    condBr = InverseBranch(condBr);
-									    int tmp = brKey;
-									    brKey = nextKey;
-									    nextKey = tmp;
-								    }
+									if (ctx.Random.NextBoolean()) {
+										condBr = InverseBranch(condBr);
+										int tmp = brKey;
+										brKey = nextKey;
+										nextKey = tmp;
+									}
 
-								    var thisKey = key[i];
-								    int r = 0, xorKey = 0;
-								    if (!unkSrc) {
-									    r = ctx.Random.NextInt32();
-									    xorKey = thisKey * r;
-								    }
+									var thisKey = key[i];
+									int r = 0, xorKey = 0;
+									if (!unkSrc) {
+										r = ctx.Random.NextInt32();
+										xorKey = thisKey * r;
+									}
 
-								    Instruction brKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(brKey) : brKey));
-								    Instruction nextKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(nextKey) : nextKey));
-								    Instruction pop = Instruction.Create(OpCodes.Pop);
+									Instruction brKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(brKey) : brKey));
+									Instruction nextKeyInstr = Instruction.CreateLdcI4(xorKey ^ (predicate != null ? predicate.GetSwitchKey(nextKey) : nextKey));
+									Instruction pop = Instruction.Create(OpCodes.Pop);
 
-								    newStatement.Add(Instruction.Create(condBr, brKeyInstr));
-								    newStatement.Add(nextKeyInstr);
-								    newStatement.Add(Instruction.Create(OpCodes.Dup));
-								    newStatement.Add(Instruction.Create(OpCodes.Br, pop));
-								    newStatement.Add(brKeyInstr);
-								    newStatement.Add(Instruction.Create(OpCodes.Dup));
-								    newStatement.Add(pop);
+									newStatement.Add(Instruction.Create(condBr, brKeyInstr));
+									newStatement.Add(nextKeyInstr);
+									newStatement.Add(Instruction.Create(OpCodes.Dup));
+									newStatement.Add(Instruction.Create(OpCodes.Br, pop));
+									newStatement.Add(brKeyInstr);
+									newStatement.Add(Instruction.Create(OpCodes.Dup));
+									newStatement.Add(pop);
 
-								    if (!unkSrc) {
-									    newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
-									    newStatement.Add(Instruction.CreateLdcI4(r));
-									    newStatement.Add(Instruction.Create(OpCodes.Mul));
-									    newStatement.Add(Instruction.Create(OpCodes.Xor));
-								    }
+									if (!unkSrc) {
+										newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
+										newStatement.Add(Instruction.CreateLdcI4(r));
+										newStatement.Add(Instruction.Create(OpCodes.Mul));
+										newStatement.Add(Instruction.Create(OpCodes.Xor));
+									}
 
-								    ctx.AddJump(newStatement, switchHdr[1]);
-								    ctx.AddJunk(newStatement);
+									ctx.AddJump(newStatement, switchHdr[1]);
+									ctx.AddJunk(newStatement);
 
-                                    converted = true;
-                                }
+									converted = true;
+								}
 
-                                if (trace.BeforeStack[newStatement[0].Offset] == 0)
-                                {
-                                    operands[keyId[i]] = newStatement[0];
-                                }
+								if (trace.BeforeStack[newStatement[0].Offset] == 0)
+								{
+									operands[keyId[i]] = newStatement[0];
+								}
 							}
 						}
 
 						if (!converted) {
 							// Normal
 
-						    if (newStatement[newStatement.Count - 1].OpCode != OpCodes.Ret)
-						    {
-						        var nextStatement = current.Next;
-						        if (trace.BeforeStack[nextStatement.Value[0].Offset] == 0)
-						        {
-						            var targetKey = predicate != null ? predicate.GetSwitchKey(key[i + 1]) : key[i + 1];
-						            if (!hasUnknownSource(newStatement) && trace.BeforeStack[newStatement[0].Offset] == 0)
-						            {
-						                var thisKey = key[i];
-						                var r = ctx.Random.NextInt32();
-						                newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
-						                newStatement.Add(Instruction.CreateLdcI4(r));
-						                newStatement.Add(Instruction.Create(OpCodes.Mul));
-						                newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey*r) ^ targetKey));
-						                newStatement.Add(Instruction.Create(OpCodes.Xor));
-						            }
-						            else
-						            {
-						                newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
-						            }
+							if (newStatement[newStatement.Count - 1].OpCode != OpCodes.Ret)
+							{
+								var nextStatement = current.Next;
+								if (trace.BeforeStack[nextStatement.Value[0].Offset] == 0)
+								{
+									var targetKey = predicate != null ? predicate.GetSwitchKey(key[i + 1]) : key[i + 1];
+									if (!hasUnknownSource(newStatement) && trace.BeforeStack[newStatement[0].Offset] == 0)
+									{
+										var thisKey = key[i];
+										var r = ctx.Random.NextInt32();
+										newStatement.Add(Instruction.Create(OpCodes.Ldloc, local));
+										newStatement.Add(Instruction.CreateLdcI4(r));
+										newStatement.Add(Instruction.Create(OpCodes.Mul));
+										newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, (thisKey*r) ^ targetKey));
+										newStatement.Add(Instruction.Create(OpCodes.Xor));
+									}
+									else
+									{
+										newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
+									}
 
-						            ctx.AddJump(newStatement, switchHdr[1]);
-						            ctx.AddJunk(newStatement);
-						        }
-						        else
-						        {
-						            newStatement.Add(Instruction.Create(OpCodes.Br, nextStatement.Value[0]));
-						        }
-						    }
+									ctx.AddJump(newStatement, switchHdr[1]);
+									ctx.AddJunk(newStatement);
+								}
+								else
+								{
+									newStatement.Add(Instruction.Create(OpCodes.Br, nextStatement.Value[0]));
+								}
+							}
 
-						    if (trace.BeforeStack[newStatement[0].Offset] == 0)
-                            {
-                                operands[keyId[i]] = newStatement[0];
-                            }
-                        }
+							if (trace.BeforeStack[newStatement[0].Offset] == 0)
+							{
+								operands[keyId[i]] = newStatement[0];
+							}
+						}
 					}
 					else
 						operands[keyId[i]] = switchHdr[0];
@@ -440,10 +440,10 @@ namespace Confuser.Protections.ControlFlow {
 					i++;
 				}
 
-			    if (trace.BeforeStack[current.Value[0].Offset] == 0)
-			    {
-			        operands[keyId[i]] = current.Value[0];
-			    }
+				if (trace.BeforeStack[current.Value[0].Offset] == 0)
+				{
+					operands[keyId[i]] = current.Value[0];
+				}
 
 			    for (i = 0; i < operands.Length; i++)
 			    {
@@ -463,16 +463,16 @@ namespace Confuser.Protections.ControlFlow {
 				List<Instruction[]> newStatements = statements.Where(s => trace.BeforeStack[s[0].Offset] == 0).ToList();
 				ctx.Random.Shuffle(newStatements);
 
-                List<Instruction[]> newOrderedStatements = statements.Where(s => trace.BeforeStack[s[0].Offset] != 0).ToList();
+				List<Instruction[]> newOrderedStatements = statements.Where(s => trace.BeforeStack[s[0].Offset] != 0).ToList();
 
-                block.Instructions.Clear();
+				block.Instructions.Clear();
 				block.Instructions.AddRange(first);
 				block.Instructions.AddRange(switchHdr);
 				foreach (var statement in newStatements)
 					block.Instructions.AddRange(statement);
-                foreach (var statement in newOrderedStatements)
-                    block.Instructions.AddRange(statement);
-                block.Instructions.AddRange(last);
+				foreach (var statement in newOrderedStatements)
+					block.Instructions.AddRange(statement);
+				block.Instructions.AddRange(last);
 			}
 		}
 	}


### PR DESCRIPTION
There's an example project demonstrating the issue here: https://github.com/jbeshir/confuserex-badilreplication

The problem appears to be that when compiling code using the C# 6 null propagation operator, the VS 2015 C# compiler creates IL which results in statements whose first instruction has a non-zero BeforeStack being returned from SplitStatements, with an example in the README attached to that example.

The switch mangler doesn't support this for multiple reasons; having both the switch instruction and the branch going to the statement results in inconsistent evaluation stack for multiple branches to that location, the statement is allowed to appear before the branch to it, which violates a backwards branch constraint, and if the last statement has a non-zero BeforeStack the jump to it after the switch instruction fails to work.

This adds support for statements which have non-zero BeforeStack. It does so by dropping them from the switch instruction's operands (which we never expect to try to go to them), changing the jump after the switch statement if the last statement has a non-zero BeforeStack (in which case we never expect to hit it), not transforming branches which are going to such statements to run via the switch instruction (since it has the wrong state for the evaluation stack), treating those blocks as having unknown source (which is needed to make it work given the previous change), and maintaining the order of blocks which have non-zero BeforeStack and putting them after all other blocks except the last (to avoid backwards branch constraint violations).

This might make such blocks a bit less well obfuscated compared to regular blocks, and there might be other details which need handling that I've not noticed; I'm new to working on IL generation in general.

This resolves the project replicating the issue, and I've tested this on a large project using null propagation when raising events heavily and found it appears to work well and not break anything.