### PR TITLE
Appending file extension when saving project

### DIFF
--- a/ConfuserEx/ViewModel/UI/AppVM.cs
+++ b/ConfuserEx/ViewModel/UI/AppVM.cs
@@ -84,6 +84,8 @@ namespace ConfuserEx.ViewModel {
 				var sfd = new VistaSaveFileDialog();
 				sfd.FileName = FileName;
 				sfd.Filter = "ConfuserEx Projects (*.crproj)|*.crproj|All Files (*.*)|*.*";
+			    sfd.DefaultExt = ".crproj";
+			    sfd.AddExtension = true;
 				if (!(sfd.ShowDialog(Application.Current.MainWindow) ?? false) || sfd.FileName == null)
 					return false;
 				FileName = sfd.FileName;


### PR DESCRIPTION
It's very usual only write the file name, without the extension.
And it's get worse when you have a name like 'Job.Task.Core'.
With my pull, you always have de '.crproj' at the end (ex: Job.Task.Core.crproj'
I also recomend that you use space instead tabs and the open brace stay at the next line.