### PR TITLE
Explanation of the `argument` XML element

### DIFF
--- a/docs/ProjectFormat.md
+++ b/docs/ProjectFormat.md
@@ -114,6 +114,18 @@ The identifier of the protection/packer.
 The arguments that passed to the protection.
 Optional.
 
+Element `argument`
+------------------
+
+An argument that is passed to a protection.
+
+**Attributes:**
+
+`name`:
+The name of the argument.
+
+`value`:
+The value of the argument.
 
 Applying rules
 --------------


### PR DESCRIPTION
I believe the format of the `argument` element should also be explained.
When I tried to create a `crproj` file I assumed the format was `<argument renPublic="true"/>` instead of the correct `<argument name="renPublic" value="true"/>`.