### PR TITLE
This commit fixes the issues with WPF obfuscation. This issue arises …

### DIFF
--- a/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
@@ -12,291 +12,351 @@ using dnlib.DotNet;
 using dnlib.DotNet.Emit;
 using dnlib.IO;
 
-namespace Confuser.Renamer.Analyzers {
-	internal class WPFAnalyzer : IRenamer {
-		static readonly object BAMLKey = new object();
+namespace Confuser.Renamer.Analyzers
+{
+    internal class WPFAnalyzer : IRenamer
+    {
+        static readonly object BAMLKey = new object();
 
-		static readonly Regex ResourceNamePattern = new Regex("^.*\\.g\\.resources$");
-		internal static readonly Regex UriPattern = new Regex(";COMPONENT/(.+\\.[BX]AML)$");
-		BAMLAnalyzer analyzer;
+        static readonly Regex ResourceNamePattern = new Regex("^.*\\.g\\.resources$");
+        internal static readonly Regex UriPattern = new Regex(";COMPONENT/(.+\\.[BX]AML)$");
+        BAMLAnalyzer analyzer;
 
-		internal Dictionary<string, List<IBAMLReference>> bamlRefs = new Dictionary<string, List<IBAMLReference>>(StringComparer.OrdinalIgnoreCase);
-		public event Action<BAMLAnalyzer, BamlElement> AnalyzeBAMLElement;
+        internal Dictionary<string, List<IBAMLReference>> bamlRefs = new Dictionary<string, List<IBAMLReference>>(StringComparer.OrdinalIgnoreCase);
+        public event Action<BAMLAnalyzer, BamlElement> AnalyzeBAMLElement;
 
-		public void Analyze(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def) {
-			var method = def as MethodDef;
-			if (method != null) {
-				if (!method.HasBody)
-					return;
-				AnalyzeMethod(context, service, method);
-			}
+        public void Analyze(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def)
+        {
+            var method = def as MethodDef;
+            if (method != null)
+            {
+                if (!method.HasBody)
+                    return;
+                AnalyzeMethod(context, service, method);
+            }
 
-			var module = def as ModuleDefMD;
-			if (module != null) {
-				AnalyzeResources(context, service, module);
-			}
-		}
+            var module = def as ModuleDefMD;
+            if (module != null)
+            {
+                AnalyzeResources(context, service, module);
+            }
+        }
 
-		public void PreRename(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def) {
-			var module = def as ModuleDefMD;
-			if (module == null || !parameters.GetParameter<bool>(context, def, "renXaml", true))
-				return;
+        public void PreRename(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def)
+        {
+            var module = def as ModuleDefMD;
+            if (module == null || !parameters.GetParameter<bool>(context, def, "renXaml", true))
+                return;
 
-			var wpfResInfo = context.Annotations.Get<Dictionary<string, Dictionary<string, BamlDocument>>>(module, BAMLKey);
-			if (wpfResInfo == null)
-				return;
+            var wpfResInfo = context.Annotations.Get<Dictionary<string, Dictionary<string, BamlDocument>>>(module, BAMLKey);
+            if (wpfResInfo == null)
+                return;
 
-			foreach (var res in wpfResInfo.Values)
-				foreach (var doc in res.Values) {
-					List<IBAMLReference> references;
-					if (bamlRefs.TryGetValue(doc.DocumentName, out references)) {
-						var newName = doc.DocumentName.ToUpperInvariant();
-						if (newName.EndsWith(".BAML"))
-							newName = service.RandomName(RenameMode.Letters).ToLowerInvariant() + ".baml";
-						else if (newName.EndsWith(".XAML"))
-							newName = service.RandomName(RenameMode.Letters).ToLowerInvariant() + ".xaml";
+            foreach (var res in wpfResInfo.Values)
+                foreach (var doc in res.Values)
+                {
+                    List<IBAMLReference> references;
+                    if (bamlRefs.TryGetValue(doc.DocumentName, out references))
+                    {
+                        var newName = doc.DocumentName.ToUpperInvariant();
+                        #region old code
+                        //if (newName.EndsWith(".BAML"))
+                        //    newName = service.RandomName(RenameMode.Letters).ToLowerInvariant() + ".baml";
+                        //else if (newName.EndsWith(".XAML"))
+                        //    newName = service.RandomName(RenameMode.Letters).ToLowerInvariant() + ".xaml";
+                        #endregion
 
-						bool renameOk = true;
-						foreach (var bamlRef in references)
-							if (!bamlRef.CanRename(doc.DocumentName, newName)) {
-								renameOk = false;
-								break;
-							}
+                        #region Niks patch fix
+                        /*
+                         * Nik's patch for maintaining relative paths. If the xaml file is referenced in this manner
+                         * "/some.namespace;component/somefolder/somecontrol.xaml"
+                         * then we want to keep the relative path and namespace intact. We should be obfuscating it like this - /some.namespace;component/somefolder/asjdjh2398498dswk.xaml
+                        * */
 
-						if (renameOk) {
-							foreach (var bamlRef in references)
-								bamlRef.Rename(doc.DocumentName, newName);
-							doc.DocumentName = newName;
-						}
-					}
-				}
-		}
+                        string[] completePath = newName.Split(new string[] { "/" }, StringSplitOptions.RemoveEmptyEntries);
+                        string newShinyName = string.Empty;
+                        for (int i = 0; i <= completePath.Length - 2; i++)
+                        {
+                            newShinyName += completePath[i].ToLowerInvariant() + "/";
+                        }
+                        if (newName.EndsWith(".BAML"))
+                            newName = newShinyName + service.RandomName(RenameMode.Letters).ToLowerInvariant() + ".baml";
+                        else if (newName.EndsWith(".XAML"))
+                            newName = newShinyName + service.RandomName(RenameMode.Letters).ToLowerInvariant() + ".xaml";
 
-		public void PostRename(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def) {
-			var module = def as ModuleDefMD;
-			if (module == null)
-				return;
+                        context.Logger.Debug(String.Format("Preserving virtual paths. Replaced {0} with {1}", doc.DocumentName, newName));
+                        #endregion
+                        bool renameOk = true;
+                        foreach (var bamlRef in references)
+                            if (!bamlRef.CanRename(doc.DocumentName, newName))
+                            {
+                                renameOk = false;
+                                break;
+                            }
 
-			var wpfResInfo = context.Annotations.Get<Dictionary<string, Dictionary<string, BamlDocument>>>(module, BAMLKey);
-			if (wpfResInfo == null)
-				return;
+                        if (renameOk)
+                        {
+                            foreach (var bamlRef in references)
+                                bamlRef.Rename(doc.DocumentName, newName);
+                            doc.DocumentName = newName;
+                        }
+                    }
+                }
+        }
 
-			foreach (EmbeddedResource res in module.Resources.OfType<EmbeddedResource>()) {
-				Dictionary<string, BamlDocument> resInfo;
+        public void PostRename(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def)
+        {
+            var module = def as ModuleDefMD;
+            if (module == null)
+                return;
 
-				if (!wpfResInfo.TryGetValue(res.Name, out resInfo))
-					continue;
+            var wpfResInfo = context.Annotations.Get<Dictionary<string, Dictionary<string, BamlDocument>>>(module, BAMLKey);
+            if (wpfResInfo == null)
+                return;
 
-				var stream = new MemoryStream();
-				var writer = new ResourceWriter(stream);
+            foreach (EmbeddedResource res in module.Resources.OfType<EmbeddedResource>())
+            {
+                Dictionary<string, BamlDocument> resInfo;
 
-				res.Data.Position = 0;
-				var reader = new ResourceReader(new ImageStream(res.Data));
-				IDictionaryEnumerator enumerator = reader.GetEnumerator();
-				while (enumerator.MoveNext()) {
-					var name = (string)enumerator.Key;
-					string typeName;
-					byte[] data;
-					reader.GetResourceData(name, out typeName, out data);
+                if (!wpfResInfo.TryGetValue(res.Name, out resInfo))
+                    continue;
 
-					BamlDocument document;
-					if (resInfo.TryGetValue(name, out document)) {
-						var docStream = new MemoryStream();
-						docStream.Position = 4;
-						BamlWriter.WriteDocument(document, docStream);
-						docStream.Position = 0;
-						docStream.Write(BitConverter.GetBytes((int)docStream.Length - 4), 0, 4);
-						data = docStream.ToArray();
-						name = document.DocumentName;
-					}
+                var stream = new MemoryStream();
+                var writer = new ResourceWriter(stream);
 
-					writer.AddResourceData(name, typeName, data);
-				}
-				writer.Generate();
-				res.Data = MemoryImageStream.Create(stream.ToArray());
-			}
-		}
+                res.Data.Position = 0;
+                var reader = new ResourceReader(new ImageStream(res.Data));
+                IDictionaryEnumerator enumerator = reader.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    var name = (string)enumerator.Key;
+                    string typeName;
+                    byte[] data;
+                    reader.GetResourceData(name, out typeName, out data);
 
-		void AnalyzeMethod(ConfuserContext context, INameService service, MethodDef method) {
-			var dpRegInstrs = new List<Tuple<bool, Instruction>>();
-			var routedEvtRegInstrs = new List<Instruction>();
-			foreach (Instruction instr in method.Body.Instructions) {
-				if ((instr.OpCode.Code == Code.Call || instr.OpCode.Code == Code.Callvirt)) {
-					var regMethod = (IMethod)instr.Operand;
+                    BamlDocument document;
+                    if (resInfo.TryGetValue(name, out document))
+                    {
+                        var docStream = new MemoryStream();
+                        docStream.Position = 4;
+                        BamlWriter.WriteDocument(document, docStream);
+                        docStream.Position = 0;
+                        docStream.Write(BitConverter.GetBytes((int)docStream.Length - 4), 0, 4);
+                        data = docStream.ToArray();
+                        name = document.DocumentName;
+                    }
 
-					if (regMethod.DeclaringType.FullName == "System.Windows.DependencyProperty" &&
-					    regMethod.Name.String.StartsWith("Register")) {
-						dpRegInstrs.Add(Tuple.Create(regMethod.Name.String.StartsWith("RegisterAttached"), instr));
-					}
-					else if (regMethod.DeclaringType.FullName == "System.Windows.EventManager" &&
-					         regMethod.Name.String == "RegisterRoutedEvent") {
-						routedEvtRegInstrs.Add(instr);
-					}
-				}
-				else if (instr.OpCode == OpCodes.Ldstr) {
-					var operand = ((string)instr.Operand).ToUpperInvariant();
-					if (operand.EndsWith(".BAML") || operand.EndsWith(".XAML")) {
-						var match = UriPattern.Match(operand);
-						if (match.Success)
-							operand = match.Groups[1].Value;
+                    writer.AddResourceData(name, typeName, data);
+                }
+                writer.Generate();
+                res.Data = MemoryImageStream.Create(stream.ToArray());
+            }
+        }
 
-						var reference = new BAMLStringReference(instr);
-						operand = operand.TrimStart('/');
-						var baml = operand.Substring(0, operand.Length - 5) + ".BAML";
-						var xaml = operand.Substring(0, operand.Length - 5) + ".XAML";
-						bamlRefs.AddListEntry(baml, reference);
-						bamlRefs.AddListEntry(xaml, reference);
-					}
-				}
-			}
+        void AnalyzeMethod(ConfuserContext context, INameService service, MethodDef method)
+        {
+            var dpRegInstrs = new List<Tuple<bool, Instruction>>();
+            var routedEvtRegInstrs = new List<Instruction>();
+            foreach (Instruction instr in method.Body.Instructions)
+            {
+                if ((instr.OpCode.Code == Code.Call || instr.OpCode.Code == Code.Callvirt))
+                {
+                    var regMethod = (IMethod)instr.Operand;
 
-			if (dpRegInstrs.Count == 0)
-				return;
+                    if (regMethod.DeclaringType.FullName == "System.Windows.DependencyProperty" &&
+                        regMethod.Name.String.StartsWith("Register"))
+                    {
+                        dpRegInstrs.Add(Tuple.Create(regMethod.Name.String.StartsWith("RegisterAttached"), instr));
+                    }
+                    else if (regMethod.DeclaringType.FullName == "System.Windows.EventManager" &&
+                             regMethod.Name.String == "RegisterRoutedEvent")
+                    {
+                        routedEvtRegInstrs.Add(instr);
+                    }
+                }
+                else if (instr.OpCode == OpCodes.Ldstr)
+                {
+                    var operand = ((string)instr.Operand).ToUpperInvariant();
+                    if (operand.EndsWith(".BAML") || operand.EndsWith(".XAML"))
+                    {
+                        var match = UriPattern.Match(operand);
+                        if (match.Success)
+                            operand = match.Groups[1].Value;
 
-			var traceSrv = context.Registry.GetService<ITraceService>();
-			MethodTrace trace = traceSrv.Trace(method);
+                        var reference = new BAMLStringReference(instr);
+                        operand = operand.TrimStart('/');
+                        var baml = operand.Substring(0, operand.Length - 5) + ".BAML";
+                        var xaml = operand.Substring(0, operand.Length - 5) + ".XAML";
+                        bamlRefs.AddListEntry(baml, reference);
+                        bamlRefs.AddListEntry(xaml, reference);
+                    }
+                }
+            }
 
-			bool erred = false;
-			foreach (var instrInfo in dpRegInstrs) {
-				int[] args = trace.TraceArguments(instrInfo.Item2);
-				if (args == null) {
-					if (!erred)
-						context.Logger.WarnFormat("Failed to extract dependency property name in '{0}'.", method.FullName);
-					erred = true;
-					continue;
-				}
-				Instruction ldstr = method.Body.Instructions[args[0]];
-				if (ldstr.OpCode.Code != Code.Ldstr) {
-					if (!erred)
-						context.Logger.WarnFormat("Failed to extract dependency property name in '{0}'.", method.FullName);
-					erred = true;
-					continue;
-				}
+            if (dpRegInstrs.Count == 0)
+                return;
 
-				var name = (string)ldstr.Operand;
-				TypeDef declType = method.DeclaringType;
-				bool found = false;
-				if (instrInfo.Item1) // Attached DP
-				{
-					MethodDef accessor;
-					if ((accessor = declType.FindMethod("Get" + name)) != null && accessor.IsStatic) {
-						service.SetCanRename(accessor, false);
-						found = true;
-					}
-					if ((accessor = declType.FindMethod("Set" + name)) != null && accessor.IsStatic) {
-						service.SetCanRename(accessor, false);
-						found = true;
-					}
-				}
+            var traceSrv = context.Registry.GetService<ITraceService>();
+            MethodTrace trace = traceSrv.Trace(method);
 
-				// Normal DP
-				// Find CLR property for attached DP as well, because it seems attached DP can be use as normal DP as well.
-				PropertyDef property = null;
-				if ((property = declType.FindProperty(name)) != null) {
-					service.SetCanRename(property, false);
+            bool erred = false;
+            foreach (var instrInfo in dpRegInstrs)
+            {
+                int[] args = trace.TraceArguments(instrInfo.Item2);
+                if (args == null)
+                {
+                    if (!erred)
+                        context.Logger.WarnFormat("Failed to extract dependency property name in '{0}'.", method.FullName);
+                    erred = true;
+                    continue;
+                }
+                Instruction ldstr = method.Body.Instructions[args[0]];
+                if (ldstr.OpCode.Code != Code.Ldstr)
+                {
+                    if (!erred)
+                        context.Logger.WarnFormat("Failed to extract dependency property name in '{0}'.", method.FullName);
+                    erred = true;
+                    continue;
+                }
 
-					found = true;
-					if (property.GetMethod != null)
-						service.SetCanRename(property.GetMethod, false);
+                var name = (string)ldstr.Operand;
+                TypeDef declType = method.DeclaringType;
+                bool found = false;
+                if (instrInfo.Item1) // Attached DP
+                {
+                    MethodDef accessor;
+                    if ((accessor = declType.FindMethod("Get" + name)) != null && accessor.IsStatic)
+                    {
+                        service.SetCanRename(accessor, false);
+                        found = true;
+                    }
+                    if ((accessor = declType.FindMethod("Set" + name)) != null && accessor.IsStatic)
+                    {
+                        service.SetCanRename(accessor, false);
+                        found = true;
+                    }
+                }
 
-					if (property.SetMethod != null)
-						service.SetCanRename(property.SetMethod, false);
+                // Normal DP
+                // Find CLR property for attached DP as well, because it seems attached DP can be use as normal DP as well.
+                PropertyDef property = null;
+                if ((property = declType.FindProperty(name)) != null)
+                {
+                    service.SetCanRename(property, false);
 
-					if (property.HasOtherMethods) {
-						foreach (MethodDef accessor in property.OtherMethods)
-							service.SetCanRename(accessor, false);
-					}
-				}
-				if (!found) {
-					if (instrInfo.Item1)
-						context.Logger.WarnFormat("Failed to find the accessors of attached dependency property '{0}' in type '{1}'.",
-						                          name, declType.FullName);
-					else
-						context.Logger.WarnFormat("Failed to find the CLR property of normal dependency property '{0}' in type '{1}'.",
-						                          name, declType.FullName);
-				}
-			}
+                    found = true;
+                    if (property.GetMethod != null)
+                        service.SetCanRename(property.GetMethod, false);
 
-			erred = false;
-			foreach (Instruction instr in routedEvtRegInstrs) {
-				int[] args = trace.TraceArguments(instr);
-				if (args == null) {
-					if (!erred)
-						context.Logger.WarnFormat("Failed to extract routed event name in '{0}'.", method.FullName);
-					erred = true;
-					continue;
-				}
-				Instruction ldstr = method.Body.Instructions[args[0]];
-				if (ldstr.OpCode.Code != Code.Ldstr) {
-					if (!erred)
-						context.Logger.WarnFormat("Failed to extract routed event name in '{0}'.", method.FullName);
-					erred = true;
-					continue;
-				}
+                    if (property.SetMethod != null)
+                        service.SetCanRename(property.SetMethod, false);
 
-				var name = (string)ldstr.Operand;
-				TypeDef declType = method.DeclaringType;
+                    if (property.HasOtherMethods)
+                    {
+                        foreach (MethodDef accessor in property.OtherMethods)
+                            service.SetCanRename(accessor, false);
+                    }
+                }
+                if (!found)
+                {
+                    if (instrInfo.Item1)
+                        context.Logger.WarnFormat("Failed to find the accessors of attached dependency property '{0}' in type '{1}'.",
+                                                  name, declType.FullName);
+                    else
+                        context.Logger.WarnFormat("Failed to find the CLR property of normal dependency property '{0}' in type '{1}'.",
+                                                  name, declType.FullName);
+                }
+            }
 
-				EventDef eventDef = null;
-				if ((eventDef = declType.FindEvent(name)) == null) {
-					context.Logger.WarnFormat("Failed to find the CLR event of routed event '{0}' in type '{1}'.",
-					                          name, declType.FullName);
-					continue;
-				}
-				service.SetCanRename(eventDef, false);
+            erred = false;
+            foreach (Instruction instr in routedEvtRegInstrs)
+            {
+                int[] args = trace.TraceArguments(instr);
+                if (args == null)
+                {
+                    if (!erred)
+                        context.Logger.WarnFormat("Failed to extract routed event name in '{0}'.", method.FullName);
+                    erred = true;
+                    continue;
+                }
+                Instruction ldstr = method.Body.Instructions[args[0]];
+                if (ldstr.OpCode.Code != Code.Ldstr)
+                {
+                    if (!erred)
+                        context.Logger.WarnFormat("Failed to extract routed event name in '{0}'.", method.FullName);
+                    erred = true;
+                    continue;
+                }
 
-				if (eventDef.AddMethod != null)
-					service.SetCanRename(eventDef.AddMethod, false);
+                var name = (string)ldstr.Operand;
+                TypeDef declType = method.DeclaringType;
 
-				if (eventDef.RemoveMethod != null)
-					service.SetCanRename(eventDef.RemoveMethod, false);
+                EventDef eventDef = null;
+                if ((eventDef = declType.FindEvent(name)) == null)
+                {
+                    context.Logger.WarnFormat("Failed to find the CLR event of routed event '{0}' in type '{1}'.",
+                                              name, declType.FullName);
+                    continue;
+                }
+                service.SetCanRename(eventDef, false);
 
-				if (eventDef.InvokeMethod != null)
-					service.SetCanRename(eventDef.InvokeMethod, false);
+                if (eventDef.AddMethod != null)
+                    service.SetCanRename(eventDef.AddMethod, false);
 
-				if (eventDef.HasOtherMethods) {
-					foreach (MethodDef accessor in eventDef.OtherMethods)
-						service.SetCanRename(accessor, false);
-				}
-			}
-		}
+                if (eventDef.RemoveMethod != null)
+                    service.SetCanRename(eventDef.RemoveMethod, false);
 
-		void AnalyzeResources(ConfuserContext context, INameService service, ModuleDefMD module) {
-			if (analyzer == null) {
-				analyzer = new BAMLAnalyzer(context, service);
-				analyzer.AnalyzeElement += AnalyzeBAMLElement;
-			}
+                if (eventDef.InvokeMethod != null)
+                    service.SetCanRename(eventDef.InvokeMethod, false);
 
-			var wpfResInfo = new Dictionary<string, Dictionary<string, BamlDocument>>();
+                if (eventDef.HasOtherMethods)
+                {
+                    foreach (MethodDef accessor in eventDef.OtherMethods)
+                        service.SetCanRename(accessor, false);
+                }
+            }
+        }
 
-			foreach (EmbeddedResource res in module.Resources.OfType<EmbeddedResource>()) {
-				Match match = ResourceNamePattern.Match(res.Name);
-				if (!match.Success)
-					continue;
+        void AnalyzeResources(ConfuserContext context, INameService service, ModuleDefMD module)
+        {
+            if (analyzer == null)
+            {
+                analyzer = new BAMLAnalyzer(context, service);
+                analyzer.AnalyzeElement += AnalyzeBAMLElement;
+            }
 
-				var resInfo = new Dictionary<string, BamlDocument>();
+            var wpfResInfo = new Dictionary<string, Dictionary<string, BamlDocument>>();
 
-				res.Data.Position = 0;
-				var reader = new ResourceReader(new ImageStream(res.Data));
-				IDictionaryEnumerator enumerator = reader.GetEnumerator();
-				while (enumerator.MoveNext()) {
-					var name = (string)enumerator.Key;
-					if (!name.EndsWith(".baml"))
-						continue;
+            foreach (EmbeddedResource res in module.Resources.OfType<EmbeddedResource>())
+            {
+                Match match = ResourceNamePattern.Match(res.Name);
+                if (!match.Success)
+                    continue;
 
-					string typeName;
-					byte[] data;
-					reader.GetResourceData(name, out typeName, out data);
-					BamlDocument document = analyzer.Analyze(module, name, data);
-					document.DocumentName = name;
-					resInfo.Add(name, document);
-				}
+                var resInfo = new Dictionary<string, BamlDocument>();
 
-				if (resInfo.Count > 0)
-					wpfResInfo.Add(res.Name, resInfo);
-			}
-			if (wpfResInfo.Count > 0)
-				context.Annotations.Set(module, BAMLKey, wpfResInfo);
-		}
-	}
+                res.Data.Position = 0;
+                var reader = new ResourceReader(new ImageStream(res.Data));
+                IDictionaryEnumerator enumerator = reader.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    var name = (string)enumerator.Key;
+                    if (!name.EndsWith(".baml"))
+                        continue;
+
+                    string typeName;
+                    byte[] data;
+                    reader.GetResourceData(name, out typeName, out data);
+                    BamlDocument document = analyzer.Analyze(module, name, data);
+                    document.DocumentName = name;
+                    resInfo.Add(name, document);
+                }
+
+                if (resInfo.Count > 0)
+                    wpfResInfo.Add(res.Name, resInfo);
+            }
+            if (wpfResInfo.Count > 0)
+                context.Annotations.Set(module, BAMLKey, wpfResInfo);
+        }
+    }
 }

--- a/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
@@ -17,7 +17,6 @@ namespace Confuser.Renamer.Analyzers
     internal class WPFAnalyzer : IRenamer
     {
         static readonly object BAMLKey = new object();
-
         static readonly Regex ResourceNamePattern = new Regex("^.*\\.g\\.resources$");
         internal static readonly Regex UriPattern = new Regex(";COMPONENT/(.+\\.[BX]AML)$");
         BAMLAnalyzer analyzer;

--- a/Confuser.Renamer/BAML/BAMLAnalyzer.cs
+++ b/Confuser.Renamer/BAML/BAMLAnalyzer.cs
@@ -8,641 +8,745 @@ using Confuser.Renamer.Analyzers;
 using Confuser.Renamer.References;
 using dnlib.DotNet;
 
-namespace Confuser.Renamer.BAML {
-	internal class BAMLAnalyzer {
-		readonly ConfuserContext context;
-		readonly INameService service;
+namespace Confuser.Renamer.BAML
+{
+    internal class BAMLAnalyzer
+    {
+        readonly ConfuserContext context;
+        readonly INameService service;
 
-		readonly Dictionary<string, List<MethodDef>> methods = new Dictionary<string, List<MethodDef>>();
-		readonly Dictionary<string, List<EventDef>> events = new Dictionary<string, List<EventDef>>();
-		readonly Dictionary<string, List<PropertyDef>> properties = new Dictionary<string, List<PropertyDef>>();
+        readonly Dictionary<string, List<MethodDef>> methods = new Dictionary<string, List<MethodDef>>();
+        readonly Dictionary<string, List<EventDef>> events = new Dictionary<string, List<EventDef>>();
+        readonly Dictionary<string, List<PropertyDef>> properties = new Dictionary<string, List<PropertyDef>>();
 
-		readonly Dictionary<ushort, AssemblyDef> assemblyRefs = new Dictionary<ushort, AssemblyDef>();
-		readonly Dictionary<ushort, Tuple<IDnlibDef, AttributeInfoRecord, TypeDef>> attrRefs = new Dictionary<ushort, Tuple<IDnlibDef, AttributeInfoRecord, TypeDef>>();
+        readonly Dictionary<ushort, AssemblyDef> assemblyRefs = new Dictionary<ushort, AssemblyDef>();
+        readonly Dictionary<ushort, Tuple<IDnlibDef, AttributeInfoRecord, TypeDef>> attrRefs = new Dictionary<ushort, Tuple<IDnlibDef, AttributeInfoRecord, TypeDef>>();
 
-		readonly Dictionary<ushort, StringInfoRecord> strings = new Dictionary<ushort, StringInfoRecord>();
-		readonly Dictionary<ushort, TypeSig> typeRefs = new Dictionary<ushort, TypeSig>();
-		readonly Dictionary<string, List<Tuple<AssemblyDef, string>>> xmlns = new Dictionary<string, List<Tuple<AssemblyDef, string>>>();
+        readonly Dictionary<ushort, StringInfoRecord> strings = new Dictionary<ushort, StringInfoRecord>();
+        readonly Dictionary<ushort, TypeSig> typeRefs = new Dictionary<ushort, TypeSig>();
+        readonly Dictionary<string, List<Tuple<AssemblyDef, string>>> xmlns = new Dictionary<string, List<Tuple<AssemblyDef, string>>>();
 
         readonly string packScheme = System.IO.Packaging.PackUriHelper.UriSchemePack + "://";
 
         IKnownThings things;
 
-		KnownThingsv3 thingsv3;
-		KnownThingsv4 thingsv4;
-		XmlNsContext xmlnsCtx;
-
-		public event Action<BAMLAnalyzer, BamlElement> AnalyzeElement;
-
-		public ConfuserContext Context {
-			get { return context; }
-		}
-
-		public INameService NameService {
-			get { return service; }
-		}
-
-		public string CurrentBAMLName { get; set; }
-		public ModuleDefMD Module { get; set; }
-
-		public BAMLAnalyzer(ConfuserContext context, INameService service) {
-			this.context = context;
-			this.service = service;
-			PreInit();
-		}
-
-		void PreInit() {
-			// WPF will only look for public instance members
-			foreach (TypeDef type in context.Modules.SelectMany(m => m.GetTypes())) {
-				foreach (PropertyDef property in type.Properties) {
-					if (property.IsPublic() && !property.IsStatic())
-						properties.AddListEntry(property.Name, property);
-				}
-
-				foreach (EventDef evt in type.Events) {
-					if (evt.IsPublic() && !evt.IsStatic())
-						events.AddListEntry(evt.Name, evt);
-				}
-
-				foreach (MethodDef method in type.Methods) {
-					if (method.IsPublic && !method.IsStatic)
-						methods.AddListEntry(method.Name, method);
-				}
-			}
-		}
-
-		public IEnumerable<PropertyDef> LookupProperty(string name) {
-			List<PropertyDef> ret;
-			if (!properties.TryGetValue(name, out ret))
-				return Enumerable.Empty<PropertyDef>();
-			return ret;
-		}
-
-		public IEnumerable<EventDef> LookupEvent(string name) {
-			List<EventDef> ret;
-			if (!events.TryGetValue(name, out ret))
-				return Enumerable.Empty<EventDef>();
-			return ret;
-		}
-
-		public IEnumerable<MethodDef> LookupMethod(string name) {
-			List<MethodDef> ret;
-			if (!methods.TryGetValue(name, out ret))
-				return Enumerable.Empty<MethodDef>();
-			return ret;
-		}
-
-		public BamlDocument Analyze(ModuleDefMD module, string bamlName, byte[] data) {
-			this.Module = module;
-			this.CurrentBAMLName = bamlName;
-			if (module.IsClr40) {
-				things = thingsv4 ?? (thingsv4 = new KnownThingsv4(context, module));
-			}
-			else {
-				things = thingsv3 ?? (thingsv3 = new KnownThingsv3(context, module));
-			}
-
-			Debug.Assert(BitConverter.ToInt32(data, 0) == data.Length - 4);
-
-			BamlDocument document = BamlReader.ReadDocument(new MemoryStream(data, 4, data.Length - 4));
-
-			// Remove debug infos
-			document.RemoveWhere(rec => rec is LineNumberAndPositionRecord || rec is LinePositionRecord);
-
-			// Populate references
-			PopulateReferences(document);
-
-			// Process elements
-			BamlElement rootElem = BamlElement.Read(document);
-			BamlElement trueRoot = rootElem.Children.Single();
-			var stack = new Stack<BamlElement>();
-			stack.Push(rootElem);
-			while (stack.Count > 0) {
-				BamlElement elem = stack.Pop();
-				ProcessBAMLElement(trueRoot, elem);
-				foreach (BamlElement child in elem.Children)
-					stack.Push(child);
-			}
-
-			return document;
-		}
-
-		void PopulateReferences(BamlDocument document) {
-			var clrNs = new Dictionary<string, List<Tuple<AssemblyDef, string>>>();
-
-			assemblyRefs.Clear();
-			foreach (AssemblyInfoRecord rec in document.OfType<AssemblyInfoRecord>()) {
-				AssemblyDef assembly = context.Resolver.ResolveThrow(rec.AssemblyFullName, Module);
-				assemblyRefs.Add(rec.AssemblyId, assembly);
-
-				if (!context.Modules.Any(m => m.Assembly == assembly))
-					continue;
-
-				foreach (CustomAttribute attr in assembly.CustomAttributes.FindAll("System.Windows.Markup.XmlnsDefinitionAttribute")) {
-					clrNs.AddListEntry(
-						(UTF8String)attr.ConstructorArguments[0].Value,
-						Tuple.Create(assembly, (string)(UTF8String)attr.ConstructorArguments[1].Value));
-				}
-			}
-
-			xmlnsCtx = new XmlNsContext(document, assemblyRefs);
-
-			typeRefs.Clear();
-			foreach (TypeInfoRecord rec in document.OfType<TypeInfoRecord>()) {
-				AssemblyDef assembly;
-				var asmId = (short)(rec.AssemblyId & 0xfff);
-				if (asmId == -1)
-					assembly = things.FrameworkAssembly;
-				else
-					assembly = assemblyRefs[(ushort)asmId];
-
-				AssemblyDef assemblyRef = Module.Assembly == assembly ? null : assembly;
-
-				TypeSig typeSig = TypeNameParser.ParseAsTypeSigReflectionThrow(Module, rec.TypeFullName, new DummyAssemblyRefFinder(assemblyRef));
-				typeRefs[rec.TypeId] = typeSig;
-
-				AddTypeSigReference(typeSig, new BAMLTypeReference(typeSig, rec));
-			}
-
-			attrRefs.Clear();
-			foreach (AttributeInfoRecord rec in document.OfType<AttributeInfoRecord>()) {
-				TypeSig declType;
-				if (typeRefs.TryGetValue(rec.OwnerTypeId, out declType)) {
-					TypeDef type = declType.ToBasicTypeDefOrRef().ResolveTypeDefThrow();
-					attrRefs[rec.AttributeId] = AnalyzeAttributeReference(type, rec);
-				}
-				else {
-					Debug.Assert((short)rec.OwnerTypeId < 0);
-					TypeDef declTypeDef = things.Types((KnownTypes)(-(short)rec.OwnerTypeId));
-					attrRefs[rec.AttributeId] = AnalyzeAttributeReference(declTypeDef, rec);
-				}
-			}
-
-			strings.Clear();
-			foreach (StringInfoRecord rec in document.OfType<StringInfoRecord>()) {
-				strings[rec.StringId] = rec;
-			}
-
-			foreach (PIMappingRecord rec in document.OfType<PIMappingRecord>()) {
-				var asmId = (short)(rec.AssemblyId & 0xfff);
-				AssemblyDef assembly;
-				if (asmId == -1)
-					assembly = things.FrameworkAssembly;
-				else
-					assembly = assemblyRefs[(ushort)asmId];
-
-				Tuple<AssemblyDef, string> scope = Tuple.Create(assembly, rec.ClrNamespace);
-				clrNs.AddListEntry(rec.XmlNamespace, scope);
-			}
-
-			xmlns.Clear();
-			foreach (XmlnsPropertyRecord rec in document.OfType<XmlnsPropertyRecord>()) {
-				List<Tuple<AssemblyDef, string>> clrMap;
-				if (clrNs.TryGetValue(rec.XmlNamespace, out clrMap)) {
-					xmlns[rec.Prefix] = clrMap;
-					foreach (var scope in clrMap)
-						xmlnsCtx.AddNsMap(scope, rec.Prefix);
-				}
-			}
-		}
-
-		public TypeDef ResolveType(ushort typeId) {
-			if ((short)typeId < 0)
-				return things.Types((KnownTypes)(-(short)typeId));
-			return typeRefs[typeId].ToBasicTypeDefOrRef().ResolveTypeDefThrow();
-		}
-
-		TypeSig ResolveType(string typeName, out string prefix) {
-			List<Tuple<AssemblyDef, string>> clrNs;
-
-			int index = typeName.IndexOf(':');
-			if (index == -1) {
-				prefix = "";
-				if (!xmlns.TryGetValue(prefix, out clrNs))
-					return null;
-			}
-			else {
-				prefix = typeName.Substring(0, index);
-				if (!xmlns.TryGetValue(prefix, out clrNs))
-					return null;
-
-				typeName = typeName.Substring(index + 1);
-			}
-
-			foreach (var ns in clrNs) {
-				TypeSig sig = TypeNameParser.ParseAsTypeSigReflectionThrow(Module, ns.Item2 + "." + typeName, new DummyAssemblyRefFinder(ns.Item1));
-				if (sig.ToBasicTypeDefOrRef().ResolveTypeDef() != null)
-					return sig;
-			}
-			return null;
-		}
-
-		public Tuple<IDnlibDef, AttributeInfoRecord, TypeDef> ResolveAttribute(ushort attrId) {
-			if ((short)attrId < 0) {
-				Tuple<KnownTypes, PropertyDef, TypeDef> info = things.Properties((KnownProperties)(-(short)attrId));
-				return Tuple.Create<IDnlibDef, AttributeInfoRecord, TypeDef>(info.Item2, null, info.Item3);
-			}
-			return attrRefs[attrId];
-		}
-
-		void AddTypeSigReference(TypeSig typeSig, INameReference<IDnlibDef> reference) {
-			foreach (ITypeDefOrRef type in typeSig.FindTypeRefs()) {
-				TypeDef typeDef = type.ResolveTypeDefThrow();
-				if (context.Modules.Contains((ModuleDefMD)typeDef.Module)) {
-					service.ReduceRenameMode(typeDef, RenameMode.Letters);
-					service.AddReference(typeDef, reference);
-				}
-			}
-		}
-
-		void ProcessBAMLElement(BamlElement root, BamlElement elem) {
-			ProcessElementHeader(elem);
-			ProcessElementBody(root, elem);
-
-			if (AnalyzeElement != null)
-				AnalyzeElement(this, elem);
-		}
-
-		void ProcessElementHeader(BamlElement elem) {
-			// Resolve type & properties of the element.
-			switch (elem.Header.Type) {
-				case BamlRecordType.ConstructorParametersStart:
-					elem.Type = elem.Parent.Type;
-					elem.Attribute = elem.Parent.Attribute;
-					break;
-
-				case BamlRecordType.DocumentStart:
-					break;
-
-				case BamlRecordType.ElementStart:
-				case BamlRecordType.NamedElementStart:
-					elem.Type = ResolveType(((ElementStartRecord)elem.Header).TypeId);
-					elem.Attribute = elem.Parent.Attribute;
-					if (elem.Attribute != null)
-						elem.Type = GetAttributeType(elem.Attribute);
-					break;
-
-				case BamlRecordType.PropertyArrayStart:
-				case BamlRecordType.PropertyComplexStart:
-				case BamlRecordType.PropertyDictionaryStart:
-				case BamlRecordType.PropertyListStart:
-					var attrInfo = ResolveAttribute(((PropertyComplexStartRecord)elem.Header).AttributeId);
-					elem.Type = attrInfo.Item3;
-					elem.Attribute = attrInfo.Item1;
-					if (elem.Attribute != null)
-						elem.Type = GetAttributeType(elem.Attribute);
-					break;
-
-				case BamlRecordType.KeyElementStart:
-				case BamlRecordType.StaticResourceStart:
-					// i.e. <x:Key></x:Key>
-					elem.Type = Module.CorLibTypes.Object.TypeDefOrRef.ResolveTypeDef();
-					elem.Attribute = null;
-					break;
-			}
-		}
-
-		TypeDef GetAttributeType(IDnlibDef attr) {
-			ITypeDefOrRef retType = null;
-			if (attr is PropertyDef)
-				retType = ((PropertyDef)attr).PropertySig.RetType.ToBasicTypeDefOrRef();
-			else if (attr is EventDef)
-				retType = ((EventDef)attr).EventType;
-			return (retType == null) ? null : retType.ResolveTypeDefThrow();
-			throw new UnreachableException();
-		}
-
-		void ProcessElementBody(BamlElement root, BamlElement elem) {
-			foreach (BamlRecord rec in elem.Body) {
-				// Resolve the type & property for simple property record too.
-				TypeDef type = null;
-				IDnlibDef attr = null;
-				if (rec is PropertyRecord) {
-					var propRec = (PropertyRecord)rec;
-					var attrInfo = ResolveAttribute(propRec.AttributeId);
-					type = attrInfo.Item3;
-					attr = attrInfo.Item1;
-					if (attr != null)
-						type = GetAttributeType(attr);
-
-					if (attrInfo.Item1 is EventDef) {
-						MethodDef method = root.Type.FindMethod(propRec.Value);
-						if (method == null)
-							context.Logger.WarnFormat("Cannot resolve method '{0}' in '{1}'.", root.Type.FullName, propRec.Value);
-						else {
-							var reference = new BAMLAttributeReference(method, propRec);
-							service.AddReference(method, reference);
-						}
-					}
-
-					if (rec is PropertyWithConverterRecord) {
-						ProcessConverter((PropertyWithConverterRecord)rec, type);
-					}
-				}
-				else if (rec is PropertyComplexStartRecord) {
-					var attrInfo = ResolveAttribute(((PropertyComplexStartRecord)rec).AttributeId);
-					type = attrInfo.Item3;
-					attr = attrInfo.Item1;
-					if (attr != null)
-						type = GetAttributeType(attr);
-				}
-				else if (rec is ContentPropertyRecord) {
-					var attrInfo = ResolveAttribute(((ContentPropertyRecord)rec).AttributeId);
-					type = attrInfo.Item3;
-					attr = attrInfo.Item1;
-					if (elem.Attribute != null && attr != null)
-						type = GetAttributeType(attr);
-					foreach (BamlElement child in elem.Children) {
-						child.Type = type;
-						child.Attribute = attr;
-					}
-				}
-				else if (rec is PropertyCustomRecord) {
-					var customRec = (PropertyCustomRecord)rec;
-					var attrInfo = ResolveAttribute(customRec.AttributeId);
-					type = attrInfo.Item3;
-					attr = attrInfo.Item1;
-					if (elem.Attribute != null && attr != null)
-						type = GetAttributeType(attr);
-
-					if ((customRec.SerializerTypeId & 0x4000) != 0 && (customRec.SerializerTypeId & 0x4000) == 0x89) {
-						// See BamlRecordReader.GetCustomDependencyPropertyValue.
-						// Umm... Well, actually nothing to do, since this record only describe DP, which already won't be renamed.
-					}
-				}
-				else if (rec is PropertyWithExtensionRecord) {
-					var extRec = (PropertyWithExtensionRecord)rec;
-					var attrInfo = ResolveAttribute(extRec.AttributeId);
-					type = attrInfo.Item3;
-					attr = attrInfo.Item1;
-					if (elem.Attribute != null && attr != null)
-						type = GetAttributeType(attr);
-
-					if (extRec.Flags == 602) {
-						// Static Extension
-						// We only care about the references in user-defined assemblies, so skip built-in attributes
-						// Also, ValueId is a resource ID, which is not implemented, so just skip it.
-						if ((short)extRec.ValueId >= 0) {
-							attrInfo = ResolveAttribute(extRec.ValueId);
-
-							var attrTarget = attrInfo.Item1;
-							if (attrTarget == null) {
-								TypeSig declType;
-								TypeDef declTypeDef;
-								if (typeRefs.TryGetValue(attrInfo.Item2.OwnerTypeId, out declType))
-									declTypeDef = declType.ToBasicTypeDefOrRef().ResolveTypeDefThrow();
-								else {
-									Debug.Assert((short)attrInfo.Item2.OwnerTypeId < 0);
-									declTypeDef = things.Types((KnownTypes)(-(short)attrInfo.Item2.OwnerTypeId));
-								}
-								attrTarget = declTypeDef.FindField(attrInfo.Item2.Name);
-							}
-
-							if (attrTarget != null)
-								service.AddReference(attrTarget, new BAMLAttributeReference(attrTarget, attrInfo.Item2));
-						}
-					}
-				}
-				else if (rec is TextRecord) {
-					var txt = (TextRecord)rec;
-					string value = txt.Value;
-					if (txt is TextWithIdRecord)
-						value = strings[((TextWithIdRecord)txt).ValueId].Value;
-
-					string prefix;
-					TypeSig sig = ResolveType(value.Trim(), out prefix);
-					if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module)) {
-						var reference = new BAMLConverterTypeReference(xmlnsCtx, sig, txt);
-						AddTypeSigReference(sig, reference);
-					}
-					else
-						AnalyzePropertyPath(value);
-				}
-			}
-		}
-
-		void ProcessConverter(PropertyWithConverterRecord rec, TypeDef type) {
-			TypeDef converter = ResolveType(rec.ConverterTypeId);
-
-			if (converter.FullName == "System.ComponentModel.EnumConverter") {
-				if (type != null && context.Modules.Contains((ModuleDefMD)type.Module)) {
-					FieldDef enumField = type.FindField(rec.Value);
-					if (enumField != null)
-						service.AddReference(enumField, new BAMLEnumReference(enumField, rec));
-				}
-			}
-			else if (converter.FullName == "System.Windows.Input.CommandConverter") {
-				string cmd = rec.Value.Trim();
-				int index = cmd.IndexOf('.');
-				if (index != -1) {
-					string typeName = cmd.Substring(0, index);
-					string prefix;
-					TypeSig sig = ResolveType(typeName, out prefix);
-					if (sig != null) {
-						string cmdName = cmd.Substring(index + 1);
-
-						TypeDef typeDef = sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow();
-						if (context.Modules.Contains((ModuleDefMD)typeDef.Module)) {
-							PropertyDef property = typeDef.FindProperty(cmdName);
-							if (property != null) {
-								var reference = new BAMLConverterMemberReference(xmlnsCtx, sig, property, rec);
-								AddTypeSigReference(sig, reference);
-								service.ReduceRenameMode(property, RenameMode.Letters);
-								service.AddReference(property, reference);
-							}
-							FieldDef field = typeDef.FindField(cmdName);
-							if (field != null) {
-								var reference = new BAMLConverterMemberReference(xmlnsCtx, sig, field, rec);
-								AddTypeSigReference(sig, reference);
-								service.ReduceRenameMode(field, RenameMode.Letters);
-								service.AddReference(field, reference);
-							}
-							if (property == null && field == null)
-								context.Logger.WarnFormat("Could not resolve command '{0}' in '{1}'.", cmd, CurrentBAMLName);
-						}
-					}
-				}
-			}
-			else if (converter.FullName == "System.Windows.Markup.DependencyPropertyConverter") {
-				// Umm... Again nothing to do, DP already won't be renamed.
-			}
-			else if (converter.FullName == "System.Windows.PropertyPathConverter") {
-				AnalyzePropertyPath(rec.Value);
-			}
-			else if (converter.FullName == "System.Windows.Markup.RoutedEventConverter") {
-				;
-			}
-			else if (converter.FullName == "System.Windows.Markup.TypeTypeConverter") {
-				string prefix;
-				TypeSig sig = ResolveType(rec.Value.Trim(), out prefix);
-				if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module)) {
-					var reference = new BAMLConverterTypeReference(xmlnsCtx, sig, rec);
-					AddTypeSigReference(sig, reference);
-				}
-			}
-
-			var attrInfo = ResolveAttribute(rec.AttributeId);
-			string attrName = null;
-			if (attrInfo.Item1 != null)
-				attrName = attrInfo.Item1.Name;
-			else if (attrInfo.Item2 != null)
-				attrName = attrInfo.Item2.Name;
-
-			if (attrName == "DisplayMemberPath") {
-				AnalyzePropertyPath(rec.Value);
-			}
-			else if (attrName == "Source") {
-				string declType = null;
-				if (attrInfo.Item1 is IMemberDef)
-					declType = ((IMemberDef)attrInfo.Item1).DeclaringType.FullName;
-				else if (attrInfo.Item2 != null)
-					declType = ResolveType(attrInfo.Item2.OwnerTypeId).FullName;
-				if (declType == "System.Windows.ResourceDictionary") {
-					var src = rec.Value.ToUpperInvariant();
-					if (src.EndsWith(".BAML") || src.EndsWith(".XAML")) {
-						var match = WPFAnalyzer.UriPattern.Match(src);
-						if (match.Success)
-							src = match.Groups[1].Value;
-
-						if (!src.Contains("//")) {
-							var rel = new Uri(new Uri(packScheme + "application:,,,/" + CurrentBAMLName), src);
-							src = rel.LocalPath;
-						}
-						var reference = new BAMLPropertyReference(rec);
-						src = src.TrimStart('/');
-						var baml = src.Substring(0, src.Length - 5) + ".BAML";
-						var xaml = src.Substring(0, src.Length - 5) + ".XAML";
-						var bamlRefs = service.FindRenamer<WPFAnalyzer>().bamlRefs;
-						bamlRefs.AddListEntry(baml, reference);
-						bamlRefs.AddListEntry(xaml, reference);
-					}
-				}
-			}
-		}
-
-		Tuple<IDnlibDef, AttributeInfoRecord, TypeDef> AnalyzeAttributeReference(TypeDef declType, AttributeInfoRecord rec) {
-			IDnlibDef retDef = null;
-			ITypeDefOrRef retType = null;
-			while (declType != null) {
-				PropertyDef property = declType.FindProperty(rec.Name);
-				if (property != null) {
-					retDef = property;
-					retType = property.PropertySig.RetType.ToBasicTypeDefOrRef();
-					if (context.Modules.Contains((ModuleDefMD)declType.Module))
-						service.AddReference(property, new BAMLAttributeReference(property, rec));
-					break;
-				}
-
-				EventDef evt = declType.FindEvent(rec.Name);
-				if (evt != null) {
-					retDef = evt;
-					retType = evt.EventType;
-					if (context.Modules.Contains((ModuleDefMD)declType.Module))
-						service.AddReference(evt, new BAMLAttributeReference(evt, rec));
-					break;
-				}
-
-				if (declType.BaseType == null)
-					break;
-				declType = declType.BaseType.ResolveTypeDefThrow();
-			}
-			return Tuple.Create(retDef, rec, retType == null ? null : retType.ResolveTypeDefThrow());
-		}
-
-		void AnalyzePropertyPath(string path) {
-			var propertyPath = new PropertyPath(path);
-			foreach (PropertyPathPart part in propertyPath.Parts) {
-				if (part.IsAttachedDP()) {
-					string type, property;
-					part.ExtractAttachedDP(out type, out property);
-					if (type != null) {
-						string prefix;
-						TypeSig sig = ResolveType(type, out prefix);
-						if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module)) {
-							var reference = new BAMLPathTypeReference(xmlnsCtx, sig, part);
-							AddTypeSigReference(sig, reference);
-						}
-					}
-				}
-				else {
-					List<PropertyDef> candidates;
-					if (properties.TryGetValue(part.Name, out candidates))
-						foreach (PropertyDef property in candidates) {
-							service.SetCanRename(property, false);
-						}
-				}
-
-				if (part.IndexerArguments != null) {
-					foreach (PropertyPathIndexer indexer in part.IndexerArguments)
-						if (!string.IsNullOrEmpty(indexer.Type)) {
-							string prefix;
-							TypeSig sig = ResolveType(indexer.Type, out prefix);
-							if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module)) {
-								var reference = new BAMLPathTypeReference(xmlnsCtx, sig, part);
-								AddTypeSigReference(sig, reference);
-							}
-						}
-				}
-			}
-		}
-
-		class DummyAssemblyRefFinder : IAssemblyRefFinder {
-			readonly AssemblyDef assemblyDef;
-
-			public DummyAssemblyRefFinder(AssemblyDef assemblyDef) {
-				this.assemblyDef = assemblyDef;
-			}
-
-			public AssemblyRef FindAssemblyRef(TypeRef nonNestedTypeRef) {
-				return assemblyDef.ToAssemblyRef();
-			}
-		}
-
-		internal class XmlNsContext {
-			readonly Dictionary<AssemblyDef, ushort> assemblyRefs;
-			readonly BamlDocument doc;
-			readonly Dictionary<Tuple<AssemblyDef, string>, string> xmlNsMap = new Dictionary<Tuple<AssemblyDef, string>, string>();
-			int rootIndex = -1;
-			int x;
-
-			public XmlNsContext(BamlDocument doc, Dictionary<ushort, AssemblyDef> assemblyRefs) {
-				this.doc = doc;
-
-				this.assemblyRefs = new Dictionary<AssemblyDef, ushort>();
-				foreach (var entry in assemblyRefs)
-					this.assemblyRefs[entry.Value] = entry.Key;
-
-				for (int i = 0; i < doc.Count; i++)
-					if (doc[i] is ElementStartRecord) {
-						rootIndex = i + 1;
-						break;
-					}
-				Debug.Assert(rootIndex != -1);
-			}
-
-			public void AddNsMap(Tuple<AssemblyDef, string> scope, string prefix) {
-				xmlNsMap[scope] = prefix;
-			}
-
-			public string GetPrefix(string clrNs, AssemblyDef assembly) {
-				string prefix;
-				if (!xmlNsMap.TryGetValue(Tuple.Create(assembly, clrNs), out prefix)) {
-					prefix = "_" + x++;
-					ushort assemblyId = assemblyRefs[assembly];
-					doc.Insert(rootIndex, new XmlnsPropertyRecord {
-						AssemblyIds = new[] { assemblyId },
-						Prefix = prefix,
-						XmlNamespace = "clr-namespace:" + clrNs
-					});
-					doc.Insert(rootIndex - 1, new PIMappingRecord {
-						AssemblyId = assemblyId,
-						ClrNamespace = clrNs,
-						XmlNamespace = "clr-namespace:" + clrNs
-					});
-					rootIndex++;
-				}
-				return prefix;
-			}
-		}
-	}
+        KnownThingsv3 thingsv3;
+        KnownThingsv4 thingsv4;
+        XmlNsContext xmlnsCtx;
+
+        public event Action<BAMLAnalyzer, BamlElement> AnalyzeElement;
+
+        public ConfuserContext Context
+        {
+            get { return context; }
+        }
+
+        public INameService NameService
+        {
+            get { return service; }
+        }
+
+        public string CurrentBAMLName { get; set; }
+        public ModuleDefMD Module { get; set; }
+
+        public BAMLAnalyzer(ConfuserContext context, INameService service)
+        {
+            this.context = context;
+            this.service = service;
+            PreInit();
+        }
+
+        void PreInit()
+        {
+            // WPF will only look for public instance members
+            foreach (TypeDef type in context.Modules.SelectMany(m => m.GetTypes()))
+            {
+                foreach (PropertyDef property in type.Properties)
+                {
+                    if (property.IsPublic() && !property.IsStatic())
+                        properties.AddListEntry(property.Name, property);
+                }
+
+                foreach (EventDef evt in type.Events)
+                {
+                    if (evt.IsPublic() && !evt.IsStatic())
+                        events.AddListEntry(evt.Name, evt);
+                }
+
+                foreach (MethodDef method in type.Methods)
+                {
+                    if (method.IsPublic && !method.IsStatic)
+                        methods.AddListEntry(method.Name, method);
+                }
+            }
+        }
+
+        public IEnumerable<PropertyDef> LookupProperty(string name)
+        {
+            List<PropertyDef> ret;
+            if (!properties.TryGetValue(name, out ret))
+                return Enumerable.Empty<PropertyDef>();
+            return ret;
+        }
+
+        public IEnumerable<EventDef> LookupEvent(string name)
+        {
+            List<EventDef> ret;
+            if (!events.TryGetValue(name, out ret))
+                return Enumerable.Empty<EventDef>();
+            return ret;
+        }
+
+        public IEnumerable<MethodDef> LookupMethod(string name)
+        {
+            List<MethodDef> ret;
+            if (!methods.TryGetValue(name, out ret))
+                return Enumerable.Empty<MethodDef>();
+            return ret;
+        }
+
+        public BamlDocument Analyze(ModuleDefMD module, string bamlName, byte[] data)
+        {
+            this.Module = module;
+            this.CurrentBAMLName = bamlName;
+            if (module.IsClr40)
+            {
+                things = thingsv4 ?? (thingsv4 = new KnownThingsv4(context, module));
+            }
+            else
+            {
+                things = thingsv3 ?? (thingsv3 = new KnownThingsv3(context, module));
+            }
+
+            Debug.Assert(BitConverter.ToInt32(data, 0) == data.Length - 4);
+
+            BamlDocument document = BamlReader.ReadDocument(new MemoryStream(data, 4, data.Length - 4));
+
+            // Remove debug infos
+            document.RemoveWhere(rec => rec is LineNumberAndPositionRecord || rec is LinePositionRecord);
+
+            // Populate references
+            PopulateReferences(document);
+
+            // Process elements
+            BamlElement rootElem = BamlElement.Read(document);
+            BamlElement trueRoot = rootElem.Children.Single();
+            var stack = new Stack<BamlElement>();
+            stack.Push(rootElem);
+            while (stack.Count > 0)
+            {
+                BamlElement elem = stack.Pop();
+                ProcessBAMLElement(trueRoot, elem);
+                foreach (BamlElement child in elem.Children)
+                    stack.Push(child);
+            }
+
+            return document;
+        }
+
+        void PopulateReferences(BamlDocument document)
+        {
+            var clrNs = new Dictionary<string, List<Tuple<AssemblyDef, string>>>();
+
+            assemblyRefs.Clear();
+            foreach (AssemblyInfoRecord rec in document.OfType<AssemblyInfoRecord>())
+            {
+                AssemblyDef assembly = context.Resolver.ResolveThrow(rec.AssemblyFullName, Module);
+                assemblyRefs.Add(rec.AssemblyId, assembly);
+
+                if (!context.Modules.Any(m => m.Assembly == assembly))
+                    continue;
+
+                foreach (CustomAttribute attr in assembly.CustomAttributes.FindAll("System.Windows.Markup.XmlnsDefinitionAttribute"))
+                {
+                    clrNs.AddListEntry(
+                        (UTF8String)attr.ConstructorArguments[0].Value,
+                        Tuple.Create(assembly, (string)(UTF8String)attr.ConstructorArguments[1].Value));
+                }
+            }
+
+            xmlnsCtx = new XmlNsContext(document, assemblyRefs);
+
+            typeRefs.Clear();
+            foreach (TypeInfoRecord rec in document.OfType<TypeInfoRecord>())
+            {
+                AssemblyDef assembly;
+                var asmId = (short)(rec.AssemblyId & 0xfff);
+                if (asmId == -1)
+                    assembly = things.FrameworkAssembly;
+                else
+                    assembly = assemblyRefs[(ushort)asmId];
+
+                AssemblyDef assemblyRef = Module.Assembly == assembly ? null : assembly;
+
+                TypeSig typeSig = TypeNameParser.ParseAsTypeSigReflectionThrow(Module, rec.TypeFullName, new DummyAssemblyRefFinder(assemblyRef));
+                typeRefs[rec.TypeId] = typeSig;
+
+                AddTypeSigReference(typeSig, new BAMLTypeReference(typeSig, rec));
+            }
+
+            attrRefs.Clear();
+            foreach (AttributeInfoRecord rec in document.OfType<AttributeInfoRecord>())
+            {
+                TypeSig declType;
+                if (typeRefs.TryGetValue(rec.OwnerTypeId, out declType))
+                {
+                    TypeDef type = declType.ToBasicTypeDefOrRef().ResolveTypeDefThrow();
+                    attrRefs[rec.AttributeId] = AnalyzeAttributeReference(type, rec);
+                }
+                else
+                {
+                    Debug.Assert((short)rec.OwnerTypeId < 0);
+                    TypeDef declTypeDef = things.Types((KnownTypes)(-(short)rec.OwnerTypeId));
+                    attrRefs[rec.AttributeId] = AnalyzeAttributeReference(declTypeDef, rec);
+                }
+            }
+
+            strings.Clear();
+            foreach (StringInfoRecord rec in document.OfType<StringInfoRecord>())
+            {
+                strings[rec.StringId] = rec;
+            }
+
+            foreach (PIMappingRecord rec in document.OfType<PIMappingRecord>())
+            {
+                var asmId = (short)(rec.AssemblyId & 0xfff);
+                AssemblyDef assembly;
+                if (asmId == -1)
+                    assembly = things.FrameworkAssembly;
+                else
+                    assembly = assemblyRefs[(ushort)asmId];
+
+                Tuple<AssemblyDef, string> scope = Tuple.Create(assembly, rec.ClrNamespace);
+                clrNs.AddListEntry(rec.XmlNamespace, scope);
+            }
+
+            xmlns.Clear();
+            foreach (XmlnsPropertyRecord rec in document.OfType<XmlnsPropertyRecord>())
+            {
+                List<Tuple<AssemblyDef, string>> clrMap;
+                if (clrNs.TryGetValue(rec.XmlNamespace, out clrMap))
+                {
+                    xmlns[rec.Prefix] = clrMap;
+                    foreach (var scope in clrMap)
+                        xmlnsCtx.AddNsMap(scope, rec.Prefix);
+                }
+            }
+        }
+
+        public TypeDef ResolveType(ushort typeId)
+        {
+            if ((short)typeId < 0)
+                return things.Types((KnownTypes)(-(short)typeId));
+            return typeRefs[typeId].ToBasicTypeDefOrRef().ResolveTypeDefThrow();
+        }
+
+        TypeSig ResolveType(string typeName, out string prefix)
+        {
+            List<Tuple<AssemblyDef, string>> clrNs;
+
+            int index = typeName.IndexOf(':');
+            if (index == -1)
+            {
+                prefix = "";
+                if (!xmlns.TryGetValue(prefix, out clrNs))
+                    return null;
+            }
+            else
+            {
+                prefix = typeName.Substring(0, index);
+                if (!xmlns.TryGetValue(prefix, out clrNs))
+                    return null;
+
+                typeName = typeName.Substring(index + 1);
+            }
+
+            foreach (var ns in clrNs)
+            {
+                TypeSig sig = TypeNameParser.ParseAsTypeSigReflectionThrow(Module, ns.Item2 + "." + typeName, new DummyAssemblyRefFinder(ns.Item1));
+                if (sig.ToBasicTypeDefOrRef().ResolveTypeDef() != null)
+                    return sig;
+            }
+            return null;
+        }
+
+        public Tuple<IDnlibDef, AttributeInfoRecord, TypeDef> ResolveAttribute(ushort attrId)
+        {
+            if ((short)attrId < 0)
+            {
+                Tuple<KnownTypes, PropertyDef, TypeDef> info = things.Properties((KnownProperties)(-(short)attrId));
+                return Tuple.Create<IDnlibDef, AttributeInfoRecord, TypeDef>(info.Item2, null, info.Item3);
+            }
+            return attrRefs[attrId];
+        }
+
+        void AddTypeSigReference(TypeSig typeSig, INameReference<IDnlibDef> reference)
+        {
+            foreach (ITypeDefOrRef type in typeSig.FindTypeRefs())
+            {
+                TypeDef typeDef = type.ResolveTypeDefThrow();
+                if (context.Modules.Contains((ModuleDefMD)typeDef.Module))
+                {
+                    service.ReduceRenameMode(typeDef, RenameMode.Letters);
+                    service.AddReference(typeDef, reference);
+                }
+            }
+        }
+
+        void ProcessBAMLElement(BamlElement root, BamlElement elem)
+        {
+            ProcessElementHeader(elem);
+            ProcessElementBody(root, elem);
+
+            if (AnalyzeElement != null)
+                AnalyzeElement(this, elem);
+        }
+
+        void ProcessElementHeader(BamlElement elem)
+        {
+            // Resolve type & properties of the element.
+            switch (elem.Header.Type)
+            {
+                case BamlRecordType.ConstructorParametersStart:
+                    elem.Type = elem.Parent.Type;
+                    elem.Attribute = elem.Parent.Attribute;
+                    break;
+
+                case BamlRecordType.DocumentStart:
+                    break;
+
+                case BamlRecordType.ElementStart:
+                case BamlRecordType.NamedElementStart:
+                    elem.Type = ResolveType(((ElementStartRecord)elem.Header).TypeId);
+                    elem.Attribute = elem.Parent.Attribute;
+                    if (elem.Attribute != null)
+                        elem.Type = GetAttributeType(elem.Attribute);
+                    break;
+
+                case BamlRecordType.PropertyArrayStart:
+                case BamlRecordType.PropertyComplexStart:
+                case BamlRecordType.PropertyDictionaryStart:
+                case BamlRecordType.PropertyListStart:
+                    var attrInfo = ResolveAttribute(((PropertyComplexStartRecord)elem.Header).AttributeId);
+                    elem.Type = attrInfo.Item3;
+                    elem.Attribute = attrInfo.Item1;
+                    if (elem.Attribute != null)
+                        elem.Type = GetAttributeType(elem.Attribute);
+                    break;
+
+                case BamlRecordType.KeyElementStart:
+                case BamlRecordType.StaticResourceStart:
+                    // i.e. <x:Key></x:Key>
+                    elem.Type = Module.CorLibTypes.Object.TypeDefOrRef.ResolveTypeDef();
+                    elem.Attribute = null;
+                    break;
+            }
+        }
+
+        TypeDef GetAttributeType(IDnlibDef attr)
+        {
+            ITypeDefOrRef retType = null;
+            if (attr is PropertyDef)
+                retType = ((PropertyDef)attr).PropertySig.RetType.ToBasicTypeDefOrRef();
+            else if (attr is EventDef)
+                retType = ((EventDef)attr).EventType;
+            return (retType == null) ? null : retType.ResolveTypeDefThrow();
+            throw new UnreachableException();
+        }
+
+        void ProcessElementBody(BamlElement root, BamlElement elem)
+        {
+            foreach (BamlRecord rec in elem.Body)
+            {
+                // Resolve the type & property for simple property record too.
+                TypeDef type = null;
+                IDnlibDef attr = null;
+                if (rec is PropertyRecord)
+                {
+                    var propRec = (PropertyRecord)rec;
+                    var attrInfo = ResolveAttribute(propRec.AttributeId);
+                    type = attrInfo.Item3;
+                    attr = attrInfo.Item1;
+                    if (attr != null)
+                        type = GetAttributeType(attr);
+
+                    if (attrInfo.Item1 is EventDef)
+                    {
+                        MethodDef method = root.Type.FindMethod(propRec.Value);
+                        if (method == null)
+                            context.Logger.WarnFormat("Cannot resolve method '{0}' in '{1}'.", root.Type.FullName, propRec.Value);
+                        else
+                        {
+                            var reference = new BAMLAttributeReference(method, propRec);
+                            service.AddReference(method, reference);
+                        }
+                    }
+
+                    if (rec is PropertyWithConverterRecord)
+                    {
+                        ProcessConverter((PropertyWithConverterRecord)rec, type);
+                    }
+                }
+                else if (rec is PropertyComplexStartRecord)
+                {
+                    var attrInfo = ResolveAttribute(((PropertyComplexStartRecord)rec).AttributeId);
+                    type = attrInfo.Item3;
+                    attr = attrInfo.Item1;
+                    if (attr != null)
+                        type = GetAttributeType(attr);
+                }
+                else if (rec is ContentPropertyRecord)
+                {
+                    var attrInfo = ResolveAttribute(((ContentPropertyRecord)rec).AttributeId);
+                    type = attrInfo.Item3;
+                    attr = attrInfo.Item1;
+                    if (elem.Attribute != null && attr != null)
+                        type = GetAttributeType(attr);
+                    foreach (BamlElement child in elem.Children)
+                    {
+                        child.Type = type;
+                        child.Attribute = attr;
+                    }
+                }
+                else if (rec is PropertyCustomRecord)
+                {
+                    var customRec = (PropertyCustomRecord)rec;
+                    var attrInfo = ResolveAttribute(customRec.AttributeId);
+                    type = attrInfo.Item3;
+                    attr = attrInfo.Item1;
+                    if (elem.Attribute != null && attr != null)
+                        type = GetAttributeType(attr);
+
+                    if ((customRec.SerializerTypeId & 0x4000) != 0 && (customRec.SerializerTypeId & 0x4000) == 0x89)
+                    {
+                        // See BamlRecordReader.GetCustomDependencyPropertyValue.
+                        // Umm... Well, actually nothing to do, since this record only describe DP, which already won't be renamed.
+                    }
+                }
+                else if (rec is PropertyWithExtensionRecord)
+                {
+                    var extRec = (PropertyWithExtensionRecord)rec;
+                    var attrInfo = ResolveAttribute(extRec.AttributeId);
+                    type = attrInfo.Item3;
+                    attr = attrInfo.Item1;
+                    if (elem.Attribute != null && attr != null)
+                        type = GetAttributeType(attr);
+
+                    if (extRec.Flags == 602)
+                    {
+                        // Static Extension
+                        // We only care about the references in user-defined assemblies, so skip built-in attributes
+                        // Also, ValueId is a resource ID, which is not implemented, so just skip it.
+                        if ((short)extRec.ValueId >= 0)
+                        {
+                            attrInfo = ResolveAttribute(extRec.ValueId);
+
+                            var attrTarget = attrInfo.Item1;
+                            if (attrTarget == null)
+                            {
+                                TypeSig declType;
+                                TypeDef declTypeDef;
+                                if (typeRefs.TryGetValue(attrInfo.Item2.OwnerTypeId, out declType))
+                                    declTypeDef = declType.ToBasicTypeDefOrRef().ResolveTypeDefThrow();
+                                else
+                                {
+                                    Debug.Assert((short)attrInfo.Item2.OwnerTypeId < 0);
+                                    declTypeDef = things.Types((KnownTypes)(-(short)attrInfo.Item2.OwnerTypeId));
+                                }
+                                attrTarget = declTypeDef.FindField(attrInfo.Item2.Name);
+                            }
+
+                            if (attrTarget != null)
+                                service.AddReference(attrTarget, new BAMLAttributeReference(attrTarget, attrInfo.Item2));
+                        }
+                    }
+                }
+                else if (rec is TextRecord)
+                {
+                    var txt = (TextRecord)rec;
+                    string value = txt.Value;
+                    if (txt is TextWithIdRecord)
+                        value = strings[((TextWithIdRecord)txt).ValueId].Value;
+
+                    string prefix;
+                    TypeSig sig = ResolveType(value.Trim(), out prefix);
+                    if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module))
+                    {
+                        var reference = new BAMLConverterTypeReference(xmlnsCtx, sig, txt);
+                        AddTypeSigReference(sig, reference);
+                    }
+                    else
+                        AnalyzePropertyPath(value);
+                }
+            }
+        }
+
+        void ProcessConverter(PropertyWithConverterRecord rec, TypeDef type)
+        {
+            TypeDef converter = ResolveType(rec.ConverterTypeId);
+
+            if (converter.FullName == "System.ComponentModel.EnumConverter")
+            {
+                if (type != null && context.Modules.Contains((ModuleDefMD)type.Module))
+                {
+                    FieldDef enumField = type.FindField(rec.Value);
+                    if (enumField != null)
+                        service.AddReference(enumField, new BAMLEnumReference(enumField, rec));
+                }
+            }
+            else if (converter.FullName == "System.Windows.Input.CommandConverter")
+            {
+                string cmd = rec.Value.Trim();
+                int index = cmd.IndexOf('.');
+                if (index != -1)
+                {
+                    string typeName = cmd.Substring(0, index);
+                    string prefix;
+                    TypeSig sig = ResolveType(typeName, out prefix);
+                    if (sig != null)
+                    {
+                        string cmdName = cmd.Substring(index + 1);
+
+                        TypeDef typeDef = sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow();
+                        if (context.Modules.Contains((ModuleDefMD)typeDef.Module))
+                        {
+                            PropertyDef property = typeDef.FindProperty(cmdName);
+                            if (property != null)
+                            {
+                                var reference = new BAMLConverterMemberReference(xmlnsCtx, sig, property, rec);
+                                AddTypeSigReference(sig, reference);
+                                service.ReduceRenameMode(property, RenameMode.Letters);
+                                service.AddReference(property, reference);
+                            }
+                            FieldDef field = typeDef.FindField(cmdName);
+                            if (field != null)
+                            {
+                                var reference = new BAMLConverterMemberReference(xmlnsCtx, sig, field, rec);
+                                AddTypeSigReference(sig, reference);
+                                service.ReduceRenameMode(field, RenameMode.Letters);
+                                service.AddReference(field, reference);
+                            }
+                            if (property == null && field == null)
+                                context.Logger.WarnFormat("Could not resolve command '{0}' in '{1}'.", cmd, CurrentBAMLName);
+                        }
+                    }
+                }
+            }
+            else if (converter.FullName == "System.Windows.Markup.DependencyPropertyConverter")
+            {
+                // Umm... Again nothing to do, DP already won't be renamed.
+            }
+            else if (converter.FullName == "System.Windows.PropertyPathConverter")
+            {
+                AnalyzePropertyPath(rec.Value);
+            }
+            else if (converter.FullName == "System.Windows.Markup.RoutedEventConverter")
+            {
+                ;
+            }
+            else if (converter.FullName == "System.Windows.Markup.TypeTypeConverter")
+            {
+                string prefix;
+                TypeSig sig = ResolveType(rec.Value.Trim(), out prefix);
+                if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module))
+                {
+                    var reference = new BAMLConverterTypeReference(xmlnsCtx, sig, rec);
+                    AddTypeSigReference(sig, reference);
+                }
+            }
+
+            var attrInfo = ResolveAttribute(rec.AttributeId);
+            string attrName = null;
+            if (attrInfo.Item1 != null)
+                attrName = attrInfo.Item1.Name;
+            else if (attrInfo.Item2 != null)
+                attrName = attrInfo.Item2.Name;
+
+            if (attrName == "DisplayMemberPath")
+            {
+                AnalyzePropertyPath(rec.Value);
+            }
+            else if (attrName == "Source")
+            {
+                string declType = null;
+                if (attrInfo.Item1 is IMemberDef)
+                    declType = ((IMemberDef)attrInfo.Item1).DeclaringType.FullName;
+                else if (attrInfo.Item2 != null)
+                    declType = ResolveType(attrInfo.Item2.OwnerTypeId).FullName;
+                if (declType == "System.Windows.ResourceDictionary")
+                {
+                    var src = rec.Value.ToUpperInvariant();
+                    if (src.EndsWith(".BAML") || src.EndsWith(".XAML"))
+                    {
+                        var match = WPFAnalyzer.UriPattern.Match(src);
+                        if (match.Success)
+                            src = match.Groups[1].Value;
+
+                        if (!src.Contains("//"))
+                        {
+                            var rel = new Uri(new Uri(packScheme + "application:,,,/" + CurrentBAMLName), src);
+                            src = rel.LocalPath;
+                        }
+                        var reference = new BAMLPropertyReference(rec);
+                        src = src.TrimStart('/');
+                        var baml = src.Substring(0, src.Length - 5) + ".BAML";
+                        var xaml = src.Substring(0, src.Length - 5) + ".XAML";
+                        var bamlRefs = service.FindRenamer<WPFAnalyzer>().bamlRefs;
+                        bamlRefs.AddListEntry(baml, reference);
+                        bamlRefs.AddListEntry(xaml, reference);
+                    }
+                }
+            }
+        }
+
+        Tuple<IDnlibDef, AttributeInfoRecord, TypeDef> AnalyzeAttributeReference(TypeDef declType, AttributeInfoRecord rec)
+        {
+            IDnlibDef retDef = null;
+            ITypeDefOrRef retType = null;
+            while (declType != null)
+            {
+                PropertyDef property = declType.FindProperty(rec.Name);
+                if (property != null)
+                {
+                    retDef = property;
+                    retType = property.PropertySig.RetType.ToBasicTypeDefOrRef();
+                    if (context.Modules.Contains((ModuleDefMD)declType.Module))
+                        service.AddReference(property, new BAMLAttributeReference(property, rec));
+                    break;
+                }
+
+                EventDef evt = declType.FindEvent(rec.Name);
+                if (evt != null)
+                {
+                    retDef = evt;
+                    retType = evt.EventType;
+                    if (context.Modules.Contains((ModuleDefMD)declType.Module))
+                        service.AddReference(evt, new BAMLAttributeReference(evt, rec));
+                    break;
+                }
+
+                if (declType.BaseType == null)
+                    break;
+                declType = declType.BaseType.ResolveTypeDefThrow();
+            }
+            return Tuple.Create(retDef, rec, retType == null ? null : retType.ResolveTypeDefThrow());
+        }
+
+        void AnalyzePropertyPath(string path)
+        {
+            var propertyPath = new PropertyPath(path);
+            foreach (PropertyPathPart part in propertyPath.Parts)
+            {
+                if (part.IsAttachedDP())
+                {
+                    string type, property;
+                    part.ExtractAttachedDP(out type, out property);
+                    if (type != null)
+                    {
+                        string prefix;
+                        TypeSig sig = ResolveType(type, out prefix);
+                        if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module))
+                        {
+                            var reference = new BAMLPathTypeReference(xmlnsCtx, sig, part);
+                            AddTypeSigReference(sig, reference);
+                        }
+                    }
+                }
+                else
+                {
+                    List<PropertyDef> candidates;
+                    if (properties.TryGetValue(part.Name, out candidates))
+                        foreach (PropertyDef property in candidates)
+                        {
+                            service.SetCanRename(property, false);
+                        }
+                }
+
+                if (part.IndexerArguments != null)
+                {
+                    foreach (PropertyPathIndexer indexer in part.IndexerArguments)
+                        if (!string.IsNullOrEmpty(indexer.Type))
+                        {
+                            string prefix;
+                            TypeSig sig = ResolveType(indexer.Type, out prefix);
+                            if (sig != null && context.Modules.Contains((ModuleDefMD)sig.ToBasicTypeDefOrRef().ResolveTypeDefThrow().Module))
+                            {
+                                var reference = new BAMLPathTypeReference(xmlnsCtx, sig, part);
+                                AddTypeSigReference(sig, reference);
+                            }
+                        }
+                }
+            }
+        }
+
+        class DummyAssemblyRefFinder : IAssemblyRefFinder
+        {
+            readonly AssemblyDef assemblyDef;
+
+            public DummyAssemblyRefFinder(AssemblyDef assemblyDef)
+            {
+                this.assemblyDef = assemblyDef;
+            }
+
+            public AssemblyRef FindAssemblyRef(TypeRef nonNestedTypeRef)
+            {
+                return assemblyDef.ToAssemblyRef();
+            }
+        }
+
+        internal class XmlNsContext
+        {
+            readonly Dictionary<AssemblyDef, ushort> assemblyRefs;
+            readonly BamlDocument doc;
+            readonly Dictionary<Tuple<AssemblyDef, string>, string> xmlNsMap = new Dictionary<Tuple<AssemblyDef, string>, string>();
+            int rootIndex = -1;
+            int x;
+
+            public XmlNsContext(BamlDocument doc, Dictionary<ushort, AssemblyDef> assemblyRefs)
+            {
+                this.doc = doc;
+
+                this.assemblyRefs = new Dictionary<AssemblyDef, ushort>();
+                foreach (var entry in assemblyRefs)
+                    this.assemblyRefs[entry.Value] = entry.Key;
+
+                for (int i = 0; i < doc.Count; i++)
+                    if (doc[i] is ElementStartRecord)
+                    {
+                        rootIndex = i + 1;
+                        break;
+                    }
+                Debug.Assert(rootIndex != -1);
+            }
+
+            public void AddNsMap(Tuple<AssemblyDef, string> scope, string prefix)
+            {
+                xmlNsMap[scope] = prefix;
+            }
+
+            public string GetPrefix(string clrNs, AssemblyDef assembly)
+            {
+                string prefix;
+                if (!xmlNsMap.TryGetValue(Tuple.Create(assembly, clrNs), out prefix))
+                {
+                    prefix = "_" + x++;
+                    ushort assemblyId = assemblyRefs[assembly];
+                    doc.Insert(rootIndex, new XmlnsPropertyRecord
+                    {
+                        AssemblyIds = new[] { assemblyId },
+                        Prefix = prefix,
+                        XmlNamespace = "clr-namespace:" + clrNs
+                    });
+                    doc.Insert(rootIndex - 1, new PIMappingRecord
+                    {
+                        AssemblyId = assemblyId,
+                        ClrNamespace = clrNs,
+                        XmlNamespace = "clr-namespace:" + clrNs
+                    });
+                    rootIndex++;
+                }
+                return prefix;
+            }
+        }
+    }
 }

--- a/Confuser.Renamer/BAML/BAMLStringReference.cs
+++ b/Confuser.Renamer/BAML/BAMLStringReference.cs
@@ -3,30 +3,45 @@ using System.Diagnostics;
 using Confuser.Core;
 using dnlib.DotNet.Emit;
 
-namespace Confuser.Renamer.BAML {
-	public class BAMLStringReference : IBAMLReference {
-		Instruction instr;
+namespace Confuser.Renamer.BAML
+{
+    public class BAMLStringReference : IBAMLReference
+    {
+        Instruction instr;
 
-		public BAMLStringReference(Instruction instr) {
-			this.instr = instr;
-		}
+        public BAMLStringReference(Instruction instr)
+        {
+            this.instr = instr;
+        }
 
-		public bool CanRename(string oldName, string newName) {
-			// TODO: Other protection interfering
-			return instr.OpCode.Code == Code.Ldstr;
-		}
+        public bool CanRename(string oldName, string newName)
+        {
+            // TODO: Other protection interfering
+            return instr.OpCode.Code == Code.Ldstr;
+        }
 
-		public void Rename(string oldName, string newName) {
-			var value = (string)instr.Operand;
-			if (value.IndexOf(oldName, StringComparison.OrdinalIgnoreCase) != -1)
-				value = newName;
-			else if (oldName.EndsWith(".baml")) {
-				Debug.Assert(newName.EndsWith(".baml"));
-				value = newName.Substring(0, newName.Length - 5) + ".xaml";
-			}
-			else
-				throw new UnreachableException();
-			instr.Operand = value;
-		}
-	}
+        public void Rename(string oldName, string newName)
+        {
+            var value = (string)instr.Operand;
+            if (value.IndexOf(oldName, StringComparison.OrdinalIgnoreCase) != -1)
+                value = newName;
+            else if (oldName.EndsWith(".baml"))
+            {
+                Debug.Assert(newName.EndsWith(".baml"));
+                /*
+                 * Nik's patch for maintaining relative paths. If the xaml file is referenced in this manner
+                 * "/some.namespace;component/somefolder/somecontrol.xaml"
+                 * then we want to keep the relative path and namespace intact. We should be obfuscating it like this - /some.namespace;component/somefolder/asjdjh2398498dswk.xaml
+                 * */
+                //value = newName.Substring(0, newName.Length - 5) + ".xaml";
+                value = value.Replace(oldName.Replace(".baml", string.Empty, StringComparison.InvariantCultureIgnoreCase),
+                    newName.Replace(".baml", String.Empty, StringComparison.InvariantCultureIgnoreCase),
+                    StringComparison.InvariantCultureIgnoreCase);
+
+            }
+            else
+                throw new UnreachableException();
+            instr.Operand = value;
+        }
+    }
 }


### PR DESCRIPTION
…if the XAML file is nested under a folder within the root solution this change keeps the relative path of the XAML file intact while running the obfuscation engine. This is a particular issue with desktop applications that use Windows Forms and WPF together in a Visual Studio Tools for Office application. The way the .NET engine resolves the paths for XAML in this situation is based on the relative path which must remain intact.