### PR TITLE
renaming in random order

### DIFF
--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -27,8 +27,9 @@ namespace Confuser.Renamer {
 				context.CheckCancellation();
 			}
 
+			Random rng = new Random();
 			var pdbDocs = new HashSet<string>();
-			foreach (IDnlibDef def in parameters.Targets.WithProgress(context.Logger)) {
+			foreach (IDnlibDef def in parameters.Targets.OrderBy(x => rng.Next(1000)).ToArray().WithProgress(context.Logger)) {
 				if (def is ModuleDef && parameters.GetParameter(context, def, "rickroll", false))
 					RickRoller.CommenceRickroll(context, (ModuleDef)def);
 


### PR DESCRIPTION
helps to improve sequential renaming.
so far names are the same every* time for each member, which leaks information.

*as long as type count / order is the same. but its still pretty bad without random.

should this be improved by using the random seed?
not unless you want to change the random seed on every obfuscation which kinda defeats the purpose.