### PR TITLE
Fixes #403: class is renamed even if marked with ObfuscationAttribute(Exclude = true)

### DIFF
--- a/Confuser.Core/ObfAttrMarker.cs
+++ b/Confuser.Core/ObfAttrMarker.cs
@@ -108,8 +108,8 @@ namespace Confuser.Core {
 						continue;
 
 					if (info.Exclude) {
-                        if (current)
-                            settings.Clear();
+						if (current)
+							settings.Clear();
 						else if (info.ApplyToMember)
 							settings.Clear();
 						continue;

--- a/Confuser.Core/ObfAttrMarker.cs
+++ b/Confuser.Core/ObfAttrMarker.cs
@@ -108,7 +108,9 @@ namespace Confuser.Core {
 						continue;
 
 					if (info.Exclude) {
-						if (info.ApplyToMember)
+                        if (current)
+                            settings.Clear();
+						else if (info.ApplyToMember)
 							settings.Clear();
 						continue;
 					}


### PR DESCRIPTION
I'm not sure it is correct or full, but it works for my small case and a large one as well.
