### PR TITLE
Fixes #413: method's .override declaration in derived class generated incorrectly if declaring type is generic

### DIFF
--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -32,6 +32,8 @@ namespace Confuser.Renamer {
 		void SetOriginalNamespace(object obj, string ns);
 
 		void MarkHelper(IDnlibDef def, IMarkerService marker, ConfuserComponent parentComp);
+
+		string GetOriginalName(object obj);
 	}
 
 	internal class NameService : INameService {

--- a/Confuser.Renamer/References/OverrideDirectiveReference.cs
+++ b/Confuser.Renamer/References/OverrideDirectiveReference.cs
@@ -35,9 +35,13 @@ namespace Confuser.Renamer.References {
 			IMethod target;
 			if (baseSlot.MethodDefDeclType is GenericInstSig) {
 				var declType = (GenericInstSig)baseSlot.MethodDefDeclType;
-				var mode = service.GetRenameMode(method);
-				var baseMethodDefName = service.ObfuscateName(baseSlot.MethodDef.Name, mode);
-				target = new MemberRefUser(method.Module, baseMethodDefName, baseSlot.MethodDef.MethodSig, declType.ToTypeDefOrRef());
+				string name = service.GetOriginalName(baseSlot.MethodDef);
+				if (service.CanRename(baseSlot.MethodDef))
+				{
+					var mode = service.GetRenameMode(baseSlot.MethodDef);
+					name = service.ObfuscateName(name, mode);
+				}
+				target = new MemberRefUser(method.Module, name, baseSlot.MethodDef.MethodSig, declType.ToTypeDefOrRef());
 				target = (IMethod)new Importer(method.Module, ImporterOptions.TryToUseTypeDefs).Import(target);
 			}
 			else {

--- a/Confuser.Renamer/References/OverrideDirectiveReference.cs
+++ b/Confuser.Renamer/References/OverrideDirectiveReference.cs
@@ -35,7 +35,9 @@ namespace Confuser.Renamer.References {
 			IMethod target;
 			if (baseSlot.MethodDefDeclType is GenericInstSig) {
 				var declType = (GenericInstSig)baseSlot.MethodDefDeclType;
-				target = new MemberRefUser(method.Module, baseSlot.MethodDef.Name, baseSlot.MethodDef.MethodSig, declType.ToTypeDefOrRef());
+				var mode = service.GetRenameMode(method);
+				var baseMethodDefName = service.ObfuscateName(baseSlot.MethodDef.Name, mode);
+				target = new MemberRefUser(method.Module, baseMethodDefName, baseSlot.MethodDef.MethodSig, declType.ToTypeDefOrRef());
 				target = (IMethod)new Importer(method.Module, ImporterOptions.TryToUseTypeDefs).Import(target);
 			}
 			else {


### PR DESCRIPTION
When derived class is obfuscated before the base one, baseSlot.MethodDef still contains clear name. If we put it directly and it is obfuscated afterwards - we'll get a situation where base class declares obfuscated name, while derived class tries to override clear-text one, leading to MissingMethodException at the class loading time when result assembly is ran.

Not sure whether it is a correct fix though. And `baseSlot` is also used in non-generic codepath, but in slightly other manner (via direct reference to a `MethodDef` unlike plain string in generic variant)... so it might or might not be ok - would be great if reviewed thoroughly.