### PR TITLE
Update AntiDebug.Win32.cs

### DIFF
--- a/Confuser.Runtime/AntiDebug.Win32.cs
+++ b/Confuser.Runtime/AntiDebug.Win32.cs
@@ -22,7 +22,7 @@ namespace Confuser.Runtime {
 		[DllImport("kernel32.dll")]
 		static extern bool IsDebuggerPresent();
 
-		[DllImport("kernel32.dll")]
+		[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
 		static extern int OutputDebugString(string str);
 
 		static void Worker(object thread) {


### PR DESCRIPTION
Fixes a bug with Windows 8/10 that causes a crash using OutputDebugString