### PR TITLE
Forbid rename for generic types which are mentioned in BAML.

### DIFF
--- a/Confuser.Renamer/References/BAMLTypeReference.cs
+++ b/Confuser.Renamer/References/BAMLTypeReference.cs
@@ -19,7 +19,10 @@ namespace Confuser.Renamer.References {
 		}
 
 		public bool ShouldCancelRename() {
-			return false;
+			// For GenericInstSig we will have sig.ReflectionFullName refer to the old
+			// (unobfuscated) name, even if it should be obfuscated. Thus #424 created. If fixed,
+			// this line could be replaced with return false; as it was before.
+			return sig is GenericInstSig;
 		}
 	}
 }


### PR DESCRIPTION
Workaround for #424 until it is fixed.