### PR TITLE
Fix Properties and Events declared as internal failing rename

### DIFF
--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -204,7 +204,8 @@ namespace Confuser.Renamer {
 		}
 
 		void Analyze(NameService service, ConfuserContext context, ProtectionParameters parameters, PropertyDef property) {
-			if (IsVisibleOutside(context, parameters, property.DeclaringType) &&
+			if (IsVisibleOutside(context, parameters, property.DeclaringType &&
+			    property.IsPublic() &&
 			    IsVisibleOutside(context, parameters, property))
 				service.SetCanRename(property, false);
 
@@ -223,6 +224,7 @@ namespace Confuser.Renamer {
 
 		void Analyze(NameService service, ConfuserContext context, ProtectionParameters parameters, EventDef evt) {
 			if (IsVisibleOutside(context, parameters, evt.DeclaringType) &&
+			    evt.IsPublic() &&
 			    IsVisibleOutside(context, parameters, evt))
 				service.SetCanRename(evt, false);
 


### PR DESCRIPTION
Analyze method for Property and Event did not check if the event was public before setting CanRename = false. Internal Properties and Events were not being renamed while Methods were.