### PR TITLE
Force AssemblyResolver to find symbols from assemblies using exact matches. This setting precedes EnableFrameworkRedirect. This patch allows an assembly to target symbols that exist in multiple versions of another assembly, without crashing ConfuserEx.

### DIFF
--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -86,6 +86,7 @@ namespace Confuser.Core {
 			bool ok = false;
 			try {
 				var asmResolver = new AssemblyResolver();
+				asmResolver.FindExactMatch = true;
 				asmResolver.EnableTypeDefCache = true;
 				asmResolver.DefaultModuleContext = new ModuleContext(asmResolver);
 				context.Resolver = asmResolver;


### PR DESCRIPTION
This patch fixes a bug we found in the ConfuserEngine class when trying to obfuscate an assembly that was previously merged with ilmerge/il-repack. If assemblies A and B reference different versions of a particular assembly (say, System.dll versions 2 and 4), multi-module assembly C (result from merging A and B) will contain both these references. Now, although AssemblyResolver holds a reference to both version 2 and 4 in the CachedAssemblies dict, it'll fail to find types in one of those depending on the order. Setting the FindExactMatch flag to true will force AssemblyResolver to look for types in the right assembly version.