### PR TITLE
Add InputSymbolMap attribute to ConfuserProject to allow the map for the future runs

### DIFF
--- a/Confuser.Core/ConfuserContext.cs
+++ b/Confuser.Core/ConfuserContext.cs
@@ -75,6 +75,12 @@ namespace Confuser.Core {
 		public string OutputDirectory { get; internal set; }
 
 		/// <summary>
+		///     Gets the input symbol map (optional).
+		/// </summary>
+		/// <value>The input symbol map.</value>
+		public string InputSymbolMap { get; internal set; }
+
+		/// <summary>
 		///     Gets the packer.
 		/// </summary>
 		/// <value>The packer.</value>

--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -91,6 +91,10 @@ namespace Confuser.Core {
 				context.Resolver = asmResolver;
 				context.BaseDirectory = Path.Combine(Environment.CurrentDirectory, parameters.Project.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar);
 				context.OutputDirectory = Path.Combine(parameters.Project.BaseDirectory, parameters.Project.OutputDirectory.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar);
+
+				if (!string.IsNullOrWhiteSpace(parameters.Project.InputSymbolMap))
+					context.InputSymbolMap = Path.Combine(parameters.Project.BaseDirectory, parameters.Project.InputSymbolMap);
+
 				foreach (string probePath in parameters.Project.ProbePaths)
 					asmResolver.PostSearchPaths.Insert(0, Path.Combine(context.BaseDirectory, probePath));
 

--- a/Confuser.Core/Project/ConfuserPrj.xsd
+++ b/Confuser.Core/Project/ConfuserPrj.xsd
@@ -68,6 +68,7 @@
       </xs:sequence>
       <xs:attribute name="outputDir" type="xs:string" use="required" />
       <xs:attribute name="baseDir" type="xs:string" use="required" />
+      <xs:attribute name="inputSymbolMap" type="xs:string" use="optional" />
       <xs:attribute name="seed" type="xs:string" use="optional" />
       <xs:attribute name="debug" type="xs:boolean" default="false" />
     </xs:complexType>

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -450,6 +450,12 @@ namespace Confuser.Core.Project {
 		public string BaseDirectory { get; set; }
 
 		/// <summary>
+		///     Gets or sets the input symbol map file.
+		/// </summary>
+		/// <value>The file with input symbol map.</value>
+		public string InputSymbolMap { get; set; }
+
+		/// <summary>
 		///     Gets a list of protection rules that applies globally.
 		/// </summary>
 		/// <value>A list of protection rules.</value>
@@ -556,6 +562,11 @@ namespace Confuser.Core.Project {
 			else
 				Seed = null;
 
+			if (docElem.Attributes["inputSymbolMap"] != null)
+				InputSymbolMap = docElem.Attributes["inputSymbolMap"].Value.NullIfEmpty();
+			else
+				InputSymbolMap = null;
+
 			if (docElem.Attributes["debug"] != null)
 				Debug = bool.Parse(docElem.Attributes["debug"].Value);
 			else
@@ -597,6 +608,7 @@ namespace Confuser.Core.Project {
 		public ConfuserProject Clone() {
 			var ret = new ConfuserProject();
 			ret.Seed = Seed;
+			ret.InputSymbolMap = InputSymbolMap;
 			ret.Debug = Debug;
 			ret.OutputDirectory = OutputDirectory;
 			ret.BaseDirectory = BaseDirectory;

--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -192,10 +192,10 @@ namespace Confuser.Renamer {
 					return Utils.EncodeString(hash, asciiCharset);
 				case RenameMode.Decodable:
 					IncrementNameId();
-					return "_" + Utils.EncodeString(hash, alphaNumCharset);
+					return Utils.EncodeString(hash, alphaNumCharset);
 				case RenameMode.Sequential:
 					IncrementNameId();
-					return "_" + Utils.EncodeString(nameId, alphaNumCharset);
+					return Utils.EncodeString(nameId, alphaNumCharset);
 				default:
 
 					throw new NotSupportedException("Rename mode '" + mode + "' is not supported.");

--- a/ConfuserEx/StackTraceDecoder.xaml.cs
+++ b/ConfuserEx/StackTraceDecoder.xaml.cs
@@ -56,7 +56,7 @@ namespace ConfuserEx {
 			}
 		}
 
-		readonly Regex mapSymbolMatcher = new Regex("_[a-zA-Z0-9]+");
+		readonly Regex mapSymbolMatcher = new Regex("[a-zA-Z0-9]+");
 		readonly Regex passSymbolMatcher = new Regex("[a-zA-Z0-9_$]{23,}");
 		ReversibleRenamer renamer;
 

--- a/docs/ProjectFormat.md
+++ b/docs/ProjectFormat.md
@@ -27,6 +27,11 @@ The seed of the random generator in protection process.
 Indicates whether the debug symbols (*.pdb) are generated.
 Currently unused.
 
+`inputSymbolMap`
+Path to symbols map relative to `baseDir`.
+It if is set, rename protection will respect name mappings specified there and only generate additional ones as needed. Does not make sense for non-reversible rename modes.
+Symbol map file can be taken from previous obfuscation or created manually. Every non-empty line must contain exactly one tab character that separates two values: the first is obfuscated name and the second is original one. No duplications in either original or obfuscated names are allowed.
+
 **Elements:**
 
 `rule`:  


### PR DESCRIPTION
Sometimes it is necessary to provide a patch for obfuscated software. Having different obfuscation applied to patched version comparing with the released one effectively means the patched version cannot be deployed without replacing every obfuscated assembly.

This change makes it possible to provide a symbol map from a previous obfuscation and preserves the renames specified there.